### PR TITLE
feat(copilot): phase 1 Copilot SDK sessionful runtime (#3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ curl -fsSL https://raw.githubusercontent.com/xinhuagu/ace-copilot/main/install.s
 
 Downloads the latest pre-built release, extracts to `~/.ace-copilot/`, and adds commands to your PATH. Only requires Java 21 runtime (no build tools).
 
+> Optional: Node.js 20+ is required **only** if you opt into the GitHub Copilot sessionful runtime (`copilotRuntime: "session"`, see #3). The default `copilotRuntime: "chat"` path has no Node.js dependency. If Node is missing when `"session"` is selected, the daemon logs an ERROR at startup and falls back to `"chat"`.
+
 ### Configure & Run
 
 ```bash

--- a/ace-copilot-cli/build.gradle.kts
+++ b/ace-copilot-cli/build.gradle.kts
@@ -33,7 +33,37 @@ application {
     applicationDefaultJvmArgs = listOf("--enable-preview", "-Dlogback.configurationFile=logback-cli.xml")
 }
 
-// Include user-facing scripts and VERSION file in the distribution archive
+// Ensure the Copilot SDK sidecar's npm dependencies are installed before the
+// CLI distribution is assembled, so app.home/sidecar/node_modules exists at
+// runtime when a user opts into copilotRuntime=session (issue #3).
+//
+// Skipped automatically when npm is not available — users without npm either
+// run in source mode (which resolves to <user.dir>/ace-copilot-sidecar/) or
+// override via ACE_COPILOT_SIDECAR_DIR. A warning is logged so they know why
+// the session path will not work out of the box.
+val sidecarDir = rootProject.file("ace-copilot-sidecar")
+val installSidecarDeps = tasks.register<Exec>("installSidecarDeps") {
+    group = "build"
+    description = "Installs @github/copilot-sdk dependencies into ace-copilot-sidecar/node_modules."
+    workingDir = sidecarDir
+    commandLine("npm", "install", "--omit=dev", "--no-audit", "--no-fund")
+    inputs.file(sidecarDir.resolve("package.json"))
+    inputs.file(sidecarDir.resolve("package-lock.json"))
+    outputs.dir(sidecarDir.resolve("node_modules"))
+    onlyIf {
+        val hasNpm = ProcessBuilder("sh", "-c", "command -v npm >/dev/null 2>&1").start().waitFor() == 0
+        if (!hasNpm) {
+            logger.warn(
+                "npm not found on PATH; skipping Copilot sidecar dep install. " +
+                "Users who opt into copilotRuntime=\"session\" must provide a populated " +
+                "ACE_COPILOT_SIDECAR_DIR at runtime."
+            )
+        }
+        hasNpm
+    }
+}
+
+// Include user-facing scripts, VERSION file, and the Copilot sidecar in the distribution.
 distributions {
     main {
         contents {
@@ -48,9 +78,18 @@ distributions {
             }) {
                 into("")
             }
+            // Copilot SDK sidecar (issue #3). Resolved at runtime from <app.home>/sidecar/.
+            from(sidecarDir) {
+                into("sidecar")
+                include("sidecar.mjs", "package.json", "package-lock.json", "node_modules/**")
+            }
         }
     }
 }
+
+tasks.named("installDist") { dependsOn(installSidecarDeps) }
+tasks.named("distTar")     { dependsOn(installSidecarDeps) }
+tasks.named("distZip")     { dependsOn(installSidecarDeps) }
 
 graalvmNative {
     binaries {

--- a/ace-copilot-cli/build.gradle.kts
+++ b/ace-copilot-cli/build.gradle.kts
@@ -42,16 +42,32 @@ application {
 // override via ACE_COPILOT_SIDECAR_DIR. A warning is logged so they know why
 // the session path will not work out of the box.
 val sidecarDir = rootProject.file("ace-copilot-sidecar")
+
+// Cross-platform detection of `npm` on PATH. `sh -c "command -v npm"` doesn't
+// exist on Windows runners, so drive the check directly from the JVM.
+fun isNpmAvailable(): Boolean = try {
+    val probe = ProcessBuilder(if (org.gradle.internal.os.OperatingSystem.current().isWindows) "npm.cmd" else "npm", "--version")
+        .redirectErrorStream(true)
+        .start()
+    probe.inputStream.readAllBytes()
+    probe.waitFor() == 0
+} catch (_: Exception) {
+    false
+}
+
 val installSidecarDeps = tasks.register<Exec>("installSidecarDeps") {
     group = "build"
     description = "Installs @github/copilot-sdk dependencies into ace-copilot-sidecar/node_modules."
     workingDir = sidecarDir
-    commandLine("npm", "install", "--omit=dev", "--no-audit", "--no-fund")
+    commandLine(
+        if (org.gradle.internal.os.OperatingSystem.current().isWindows) "npm.cmd" else "npm",
+        "install", "--omit=dev", "--no-audit", "--no-fund"
+    )
     inputs.file(sidecarDir.resolve("package.json"))
     inputs.file(sidecarDir.resolve("package-lock.json"))
     outputs.dir(sidecarDir.resolve("node_modules"))
     onlyIf {
-        val hasNpm = ProcessBuilder("sh", "-c", "command -v npm >/dev/null 2>&1").start().waitFor() == 0
+        val hasNpm = isNpmAvailable()
         if (!hasNpm) {
             logger.warn(
                 "npm not found on PATH; skipping Copilot sidecar dep install. " +

--- a/ace-copilot-cli/src/main/java/dev/acecopilot/cli/BackgroundOutputBuffer.java
+++ b/ace-copilot-cli/src/main/java/dev/acecopilot/cli/BackgroundOutputBuffer.java
@@ -50,6 +50,11 @@ public final class BackgroundOutputBuffer implements OutputSink {
     }
 
     @Override
+    public void onWarning(String message) {
+        events.add(new OutputEvent.Warning(message));
+    }
+
+    @Override
     public void onStreamCancelled() {
         events.add(new OutputEvent.Cancelled());
     }
@@ -124,6 +129,7 @@ public final class BackgroundOutputBuffer implements OutputSink {
                 case OutputEvent.ToolCompleted e -> sink.onToolCompleted(
                         e.toolId(), e.toolName(), e.durationMs(), e.isError(), e.error());
                 case OutputEvent.Error e -> sink.onStreamError(e.error());
+                case OutputEvent.Warning e -> sink.onWarning(e.message());
                 case OutputEvent.Cancelled _ -> sink.onStreamCancelled();
                 case OutputEvent.PlanCreated e -> sink.onPlanCreated(e.params());
                 case OutputEvent.PlanStepStarted e -> sink.onPlanStepStarted(e.params());
@@ -152,6 +158,7 @@ public final class BackgroundOutputBuffer implements OutputSink {
                 switch (event) {
                     case OutputEvent.Text e -> sb.append(e.delta());
                     case OutputEvent.Error e -> sb.append("[error: ").append(e.error()).append("]\n");
+                    case OutputEvent.Warning e -> sb.append("[warning: ").append(e.message()).append("]\n");
                     default -> {} // skip thinking, tool use, lifecycle events
                 }
             }
@@ -177,6 +184,7 @@ public final class BackgroundOutputBuffer implements OutputSink {
         record ToolCompleted(String toolId, String toolName,
                              long durationMs, boolean isError, String error) implements OutputEvent {}
         record Error(String error) implements OutputEvent {}
+        record Warning(String message) implements OutputEvent {}
         record Cancelled() implements OutputEvent {}
         record PlanCreated(JsonNode params) implements OutputEvent {}
         record PlanStepStarted(JsonNode params) implements OutputEvent {}

--- a/ace-copilot-cli/src/main/java/dev/acecopilot/cli/ForegroundOutputSink.java
+++ b/ace-copilot-cli/src/main/java/dev/acecopilot/cli/ForegroundOutputSink.java
@@ -188,6 +188,19 @@ public final class ForegroundOutputSink implements OutputSink {
     }
 
     @Override
+    public void onWarning(String message) {
+        synchronized (lock) {
+            if (receivedTextOutput) {
+                flushMarkdown();
+            }
+            statusRenderer.hide();
+            out.printf("%s[warning: %s]%s%n", WARNING, message, RESET);
+            out.flush();
+            statusRenderer.refresh();
+        }
+    }
+
+    @Override
     public void onStreamCancelled() {
         synchronized (lock) {
             stopSpinnerInternal();

--- a/ace-copilot-cli/src/main/java/dev/acecopilot/cli/OutputSink.java
+++ b/ace-copilot-cli/src/main/java/dev/acecopilot/cli/OutputSink.java
@@ -45,6 +45,14 @@ public interface OutputSink {
     /** Receives a stream error. */
     void onStreamError(String error);
 
+    /**
+     * Receives a non-fatal warning from the daemon that should be visible to
+     * the user (e.g. remote Copilot session context reset on {@code /model}
+     * switch). Default implementation ignores it — foreground sinks override
+     * to render visibly.
+     */
+    default void onWarning(String message) {}
+
     /** Receives a stream cancellation acknowledgment. */
     void onStreamCancelled();
 

--- a/ace-copilot-cli/src/main/java/dev/acecopilot/cli/TaskStreamReader.java
+++ b/ace-copilot-cli/src/main/java/dev/acecopilot/cli/TaskStreamReader.java
@@ -173,6 +173,16 @@ public final class TaskStreamReader implements Runnable {
                     sink.onStreamError(params.get("error").asText());
                 }
             }
+            case "stream.warning" -> {
+                if (params != null) {
+                    String msg = params.path("message").asText("");
+                    if (!msg.isBlank()) {
+                        handle.appendToolEvent("stream", "warn", false, 0, msg);
+                        handle.markActivity("warning");
+                        sink.onWarning(msg);
+                    }
+                }
+            }
             case "stream.heartbeat" -> {
                 String phase = "active";
                 if (params != null) {

--- a/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/AceCopilotConfig.java
+++ b/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/AceCopilotConfig.java
@@ -125,6 +125,13 @@ public final class AceCopilotConfig {
     private String apiKey;
     private String refreshToken;
     private String model;
+    /**
+     * Copilot runtime path. {@code "chat"} = existing OpenAI-compat
+     * {@code /chat/completions} route via {@code CopilotRoutingClient}.
+     * {@code "session"} = Copilot SDK sessionful runtime via Node sidecar
+     * (issue #3). Default {@code "chat"} preserves current behavior.
+     */
+    private String copilotRuntime = "chat";
     private int maxTokens;
     private int thinkingBudget;
     private int maxTurns;
@@ -679,6 +686,15 @@ public final class AceCopilotConfig {
      */
     public String apiKey() {
         return apiKey;
+    }
+
+    /**
+     * Returns the Copilot runtime path: {@code "chat"} (default) or
+     * {@code "session"}. Only meaningful when {@link #provider()} is
+     * {@code "copilot"}. See issue #3.
+     */
+    public String copilotRuntime() {
+        return copilotRuntime;
     }
 
     /**
@@ -1382,6 +1398,14 @@ public final class AceCopilotConfig {
         if (fileConfig.model != null && !fileConfig.model.isBlank()) {
             this.model = fileConfig.model;
         }
+        if (fileConfig.copilotRuntime != null && !fileConfig.copilotRuntime.isBlank()) {
+            String v = fileConfig.copilotRuntime.trim().toLowerCase();
+            if (v.equals("chat") || v.equals("session")) {
+                this.copilotRuntime = v;
+            } else {
+                log.warn("Unknown copilotRuntime '{}' — keeping '{}'", fileConfig.copilotRuntime, this.copilotRuntime);
+            }
+        }
         if (fileConfig.maxTokens > 0) {
             this.maxTokens = fileConfig.maxTokens;
         }
@@ -1623,6 +1647,7 @@ public final class AceCopilotConfig {
         public String apiKey;
         public String refreshToken;
         public String model;
+        public String copilotRuntime;
         public int maxTokens;
         public int thinkingBudget;
         public int maxTurns;

--- a/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/AceCopilotConfig.java
+++ b/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/AceCopilotConfig.java
@@ -130,8 +130,21 @@ public final class AceCopilotConfig {
      * {@code /chat/completions} route via {@code CopilotRoutingClient}.
      * {@code "session"} = Copilot SDK sessionful runtime via Node sidecar
      * (issue #3). Default {@code "chat"} preserves current behavior.
+     *
+     * <p>Selecting {@code "session"} alone is NOT enough — it must be paired
+     * with {@link #copilotRuntimeAcceptUnsandboxed} because the Phase 1
+     * sidecar uses {@code approveAll} for SDK permission requests, which
+     * bypasses {@link dev.acecopilot.security.PermissionManager}. Phase 2
+     * (#4) replaces that with a proper permission bridge.
      */
     private String copilotRuntime = "chat";
+    /**
+     * Explicit acknowledgment that {@code copilotRuntime == "session"}
+     * currently auto-approves every SDK permission request. Without this
+     * flag set to {@code true}, the daemon refuses to enter session mode
+     * and stays on {@code "chat"} (logged at ERROR).
+     */
+    private boolean copilotRuntimeAcceptUnsandboxed = false;
     private int maxTokens;
     private int thinkingBudget;
     private int maxTurns;
@@ -692,9 +705,33 @@ public final class AceCopilotConfig {
      * Returns the Copilot runtime path: {@code "chat"} (default) or
      * {@code "session"}. Only meaningful when {@link #provider()} is
      * {@code "copilot"}. See issue #3.
+     *
+     * <p>Prefer {@link #effectiveCopilotRuntime()} for code that acts on
+     * the value — it collapses misconfigured session-without-ack back to
+     * {@code "chat"}.
      */
     public String copilotRuntime() {
         return copilotRuntime;
+    }
+
+    /** See {@link #copilotRuntimeAcceptUnsandboxed} — Phase 1 safety gate (#3). */
+    public boolean copilotRuntimeAcceptUnsandboxed() {
+        return copilotRuntimeAcceptUnsandboxed;
+    }
+
+    /**
+     * Returns the runtime path that should actually be used.
+     *
+     * <p>Returns {@code "session"} only when both {@link #copilotRuntime()}
+     * is {@code "session"} AND {@link #copilotRuntimeAcceptUnsandboxed()} is
+     * {@code true}. Otherwise returns {@code "chat"}. The mismatch case is
+     * logged once by {@code AceCopilotDaemon} at startup.
+     */
+    public String effectiveCopilotRuntime() {
+        if ("session".equalsIgnoreCase(copilotRuntime) && copilotRuntimeAcceptUnsandboxed) {
+            return "session";
+        }
+        return "chat";
     }
 
     /**
@@ -1406,6 +1443,9 @@ public final class AceCopilotConfig {
                 log.warn("Unknown copilotRuntime '{}' — keeping '{}'", fileConfig.copilotRuntime, this.copilotRuntime);
             }
         }
+        if (fileConfig.copilotRuntimeAcceptUnsandboxed != null) {
+            this.copilotRuntimeAcceptUnsandboxed = fileConfig.copilotRuntimeAcceptUnsandboxed;
+        }
         if (fileConfig.maxTokens > 0) {
             this.maxTokens = fileConfig.maxTokens;
         }
@@ -1648,6 +1688,7 @@ public final class AceCopilotConfig {
         public String refreshToken;
         public String model;
         public String copilotRuntime;
+        public Boolean copilotRuntimeAcceptUnsandboxed;
         public int maxTokens;
         public int thinkingBudget;
         public int maxTurns;

--- a/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/AceCopilotDaemon.java
+++ b/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/AceCopilotDaemon.java
@@ -2578,9 +2578,12 @@ public final class AceCopilotDaemon {
      * <p>Resolution order:
      * <ol>
      *   <li>{@code ACE_COPILOT_SIDECAR_DIR} env var, if set</li>
-     *   <li>{@code <user.dir>/ace-copilot-sidecar/}, if the script exists there
+     *   <li>{@code <user.dir>/ace-copilot-sidecar/}, if the script exists
      *       (source-tree runs via {@code ./gradlew :ace-copilot-daemon:run} or IDE)</li>
-     *   <li>{@code <app.home>/sidecar/}, if set (reserved for future installDist packaging)</li>
+     *   <li>{@code <installRoot>/sidecar/} derived from the location of this
+     *       class's JAR, for Gradle application-plugin installs where the
+     *       sidecar is packaged under {@code <appHome>/sidecar/} (see
+     *       {@code ace-copilot-cli/build.gradle.kts})</li>
      * </ol>
      */
     private static java.nio.file.Path resolveCopilotSidecarDir() {
@@ -2592,13 +2595,31 @@ public final class AceCopilotDaemon {
         if (java.nio.file.Files.exists(inSourceTree.resolve("sidecar.mjs"))) {
             return inSourceTree;
         }
-        String appHome = System.getProperty("app.home");
-        if (appHome != null && !appHome.isBlank()) {
-            var packaged = java.nio.file.Path.of(appHome, "sidecar");
-            if (java.nio.file.Files.exists(packaged.resolve("sidecar.mjs"))) {
-                return packaged;
-            }
+        var packaged = packagedSidecarDir();
+        if (packaged != null && java.nio.file.Files.exists(packaged.resolve("sidecar.mjs"))) {
+            return packaged;
         }
         return inSourceTree;
+    }
+
+    /**
+     * When launched from a Gradle application install, this class's JAR
+     * lives at {@code <appHome>/lib/ace-copilot-daemon-*.jar} and the
+     * packaged sidecar at {@code <appHome>/sidecar/}. Returns {@code null}
+     * for non-JAR or unexpected layouts.
+     */
+    private static java.nio.file.Path packagedSidecarDir() {
+        try {
+            var src = AceCopilotDaemon.class.getProtectionDomain().getCodeSource();
+            if (src == null) return null;
+            var jar = java.nio.file.Path.of(src.getLocation().toURI());
+            if (!jar.getFileName().toString().endsWith(".jar")) return null;
+            var libDir = jar.getParent();
+            if (libDir == null || !"lib".equals(libDir.getFileName().toString())) return null;
+            var appHome = libDir.getParent();
+            return appHome != null ? appHome.resolve("sidecar") : null;
+        } catch (Exception e) {
+            return null;
+        }
     }
 }

--- a/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/AceCopilotDaemon.java
+++ b/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/AceCopilotDaemon.java
@@ -467,6 +467,10 @@ public final class AceCopilotDaemon {
                 promptBudget,
                 config.braveSearchApiKey() != null,
                 skillRegistry::formatDescriptions);
+        agentHandler.setCopilotRuntimeConfig(
+                config.copilotRuntime(),
+                config.apiKey(),
+                resolveCopilotSidecarDir());
         agentHandler.setMcpInitFuture(mcpInitFuture);
         agentHandler.setRetryConfig(config.retryConfig());
         agentHandler.setAdaptiveContinuationConfig(
@@ -2540,5 +2544,37 @@ public final class AceCopilotDaemon {
                             + ", trends=" + trends
                             + ", bridge=" + candidateObservations + "/" + candidateTransitions + "/" + candidatePromoted);
         }
+    }
+
+    /**
+     * Resolves the directory that holds the ace-copilot Copilot SDK sidecar
+     * ({@code sidecar.mjs} + installed {@code node_modules}). Only used when
+     * {@code copilotRuntime} is {@code "session"} (issue #3).
+     *
+     * <p>Resolution order:
+     * <ol>
+     *   <li>{@code ACE_COPILOT_SIDECAR_DIR} env var, if set</li>
+     *   <li>{@code <user.dir>/ace-copilot-sidecar/}, if the script exists there
+     *       (source-tree runs via {@code ./gradlew :ace-copilot-daemon:run} or IDE)</li>
+     *   <li>{@code <app.home>/sidecar/}, if set (reserved for future installDist packaging)</li>
+     * </ol>
+     */
+    private static java.nio.file.Path resolveCopilotSidecarDir() {
+        String env = System.getenv("ACE_COPILOT_SIDECAR_DIR");
+        if (env != null && !env.isBlank()) {
+            return java.nio.file.Path.of(env);
+        }
+        var inSourceTree = java.nio.file.Path.of(System.getProperty("user.dir"), "ace-copilot-sidecar");
+        if (java.nio.file.Files.exists(inSourceTree.resolve("sidecar.mjs"))) {
+            return inSourceTree;
+        }
+        String appHome = System.getProperty("app.home");
+        if (appHome != null && !appHome.isBlank()) {
+            var packaged = java.nio.file.Path.of(appHome, "sidecar");
+            if (java.nio.file.Files.exists(packaged.resolve("sidecar.mjs"))) {
+                return packaged;
+            }
+        }
+        return inSourceTree;
     }
 }

--- a/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/AceCopilotDaemon.java
+++ b/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/AceCopilotDaemon.java
@@ -21,6 +21,7 @@ import dev.acecopilot.infra.event.EventBus;
 import dev.acecopilot.infra.event.SchedulerEvent;
 import dev.acecopilot.infra.health.*;
 import dev.acecopilot.llm.LlmClientFactory;
+import dev.acecopilot.llm.openai.CopilotTokenProvider;
 import dev.acecopilot.memory.AutoMemoryStore;
 import dev.acecopilot.memory.CandidateStateMachine;
 import dev.acecopilot.memory.CandidateStore;
@@ -467,9 +468,21 @@ public final class AceCopilotDaemon {
                 promptBudget,
                 config.braveSearchApiKey() != null,
                 skillRegistry::formatDescriptions);
+        // Phase 1 (#3) safety gate: session runtime only activates when the
+        // operator has explicitly acknowledged that the SDK agent currently
+        // bypasses PermissionManager. Phase 2 (#4) removes this gate when
+        // the permission bridge lands.
+        if ("session".equalsIgnoreCase(config.copilotRuntime()) && !config.copilotRuntimeAcceptUnsandboxed()) {
+            log.error(
+                "copilotRuntime='session' requested but copilotRuntimeAcceptUnsandboxed=false — "
+                + "the Phase 1 sidecar auto-approves every SDK permission request (filesystem, shell, etc.), "
+                + "which bypasses PermissionManager. Refusing to enter session mode; falling back to 'chat'. "
+                + "To opt in explicitly, add \"copilotRuntimeAcceptUnsandboxed\": true to your active profile. "
+                + "See issue #3.");
+        }
         agentHandler.setCopilotRuntimeConfig(
-                config.copilotRuntime(),
-                config.apiKey(),
+                config.effectiveCopilotRuntime(),
+                resolveCopilotGithubToken(config),
                 resolveCopilotSidecarDir());
         agentHandler.setMcpInitFuture(mcpInitFuture);
         agentHandler.setRetryConfig(config.retryConfig());
@@ -2544,6 +2557,17 @@ public final class AceCopilotDaemon {
                             + ", trends=" + trends
                             + ", bridge=" + candidateObservations + "/" + candidateTransitions + "/" + candidatePromoted);
         }
+    }
+
+    /**
+     * Resolves the raw GitHub token to pass to the Copilot SDK sidecar,
+     * using the same priority as {@link CopilotTokenProvider}: cached OAuth
+     * → configured {@code apiKey} → {@code GITHUB_TOKEN} → {@code GH_TOKEN}
+     * → {@code gh auth token}. Returns {@code null} if none resolve, in
+     * which case the sidecar defers to the SDK's {@code useLoggedInUser}.
+     */
+    private static String resolveCopilotGithubToken(AceCopilotConfig config) {
+        return CopilotTokenProvider.firstGithubTokenCandidate(config.apiKey());
     }
 
     /**

--- a/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/AceCopilotDaemon.java
+++ b/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/AceCopilotDaemon.java
@@ -480,8 +480,20 @@ public final class AceCopilotDaemon {
                 + "To opt in explicitly, add \"copilotRuntimeAcceptUnsandboxed\": true to your active profile. "
                 + "See issue #3.");
         }
+        // The session runtime launches a Node.js sidecar, which is not a
+        // prerequisite of the ace-copilot installer. Preflight node on PATH
+        // so misconfigured users see the problem at startup rather than at
+        // the first agent.prompt.
+        String effectiveRuntime = config.effectiveCopilotRuntime();
+        if ("session".equalsIgnoreCase(effectiveRuntime) && !isNodeAvailable()) {
+            log.error(
+                "copilotRuntime='session' requires Node.js on PATH (the sidecar runs under `node`), "
+                + "but `node --version` did not succeed. Refusing to enter session mode; falling back to 'chat'. "
+                + "Install Node.js 20+ from https://nodejs.org/ (or your package manager) and restart the daemon.");
+            effectiveRuntime = "chat";
+        }
         agentHandler.setCopilotRuntimeConfig(
-                config.effectiveCopilotRuntime(),
+                effectiveRuntime,
                 resolveCopilotGithubToken(config),
                 resolveCopilotSidecarDir());
         agentHandler.setMcpInitFuture(mcpInitFuture);
@@ -2556,6 +2568,31 @@ public final class AceCopilotDaemon {
                             + ", mining=" + (errorChains + stableWorkflows + convergingStrategies + degradationSignals)
                             + ", trends=" + trends
                             + ", bridge=" + candidateObservations + "/" + candidateTransitions + "/" + candidatePromoted);
+        }
+    }
+
+    /**
+     * Checks whether {@code node} is available on {@code PATH}. The session
+     * runtime spawns a Node.js sidecar; without {@code node} the first
+     * {@code agent.prompt} would fail with a generic IOException from
+     * {@link ProcessBuilder}. Preflight lets the daemon log a pointed
+     * error at startup and fall back to the chat runtime.
+     */
+    private static boolean isNodeAvailable() {
+        try {
+            var pb = new ProcessBuilder("node", "--version").redirectErrorStream(true);
+            var p = pb.start();
+            p.getInputStream().readAllBytes();
+            if (!p.waitFor(3, java.util.concurrent.TimeUnit.SECONDS)) {
+                p.destroyForcibly();
+                return false;
+            }
+            return p.exitValue() == 0;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        } catch (Exception e) {
+            return false;
         }
     }
 

--- a/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/StreamingAgentHandler.java
+++ b/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/StreamingAgentHandler.java
@@ -173,6 +173,12 @@ public final class StreamingAgentHandler {
     // that takes the session path; torn down in clearSessionMetrics.
     private final ConcurrentHashMap<String, CopilotAcpClient> sessionSidecars =
             new ConcurrentHashMap<>();
+    // Tracks the model the sidecar's SDK session was last asked to use, so we
+    // can surface an explicit warning when a mid-session /model switch causes
+    // the sidecar to drop remote context (the sidecar recreates the SDK
+    // session on model change; see sidecar.mjs).
+    private final ConcurrentHashMap<String, String> sessionLastModel =
+            new ConcurrentHashMap<>();
     private volatile String copilotRuntime = "chat";
     private volatile String copilotGithubToken;
     private volatile Path copilotSidecarDir;
@@ -1800,6 +1806,7 @@ public final class StreamingAgentHandler {
     }
 
     private void closeSessionSidecar(String sessionId) {
+        sessionLastModel.remove(sessionId);
         var client = sessionSidecars.remove(sessionId);
         if (client == null) return;
         try {
@@ -1854,6 +1861,28 @@ public final class StreamingAgentHandler {
             }
         });
 
+        // Surface /model mid-session switches loudly: the sidecar recreates the
+        // underlying SDK session on model change without replaying prior
+        // context, so remote Copilot context is effectively reset. The local
+        // transcript still reads as continuous, which is the footgun.
+        var previousModel = sessionLastModel.put(sessionId, model);
+        if (previousModel != null && !previousModel.equals(model)) {
+            String msg = "Copilot session context reset: model changed "
+                    + previousModel + " -> " + model
+                    + ". Prior conversation is retained locally but the remote Copilot session starts fresh.";
+            log.warn(msg);
+            try {
+                var p = objectMapper.createObjectNode();
+                p.put("level", "warning");
+                p.put("message", msg);
+                p.put("previousModel", previousModel);
+                p.put("currentModel", model);
+                cancelContext.sendNotification("stream.warning", p);
+            } catch (IOException e) {
+                log.debug("Failed to send stream.warning notification: {}", e.getMessage());
+            }
+        }
+
         var started = System.currentTimeMillis();
         var textBuf = new StringBuilder();
         CopilotAcpClient.SendResult r;
@@ -1897,7 +1926,11 @@ public final class StreamingAgentHandler {
                 usageNode.put("totalTokens", last.inputTokens() + last.outputTokens());
             }
         }
-        usageNode.put("llmRequests", r.usageEventCount());
+        // One sendAndWait is a single billable user turn. usageEventCount is
+        // the internal LLM-call count the SDK agent made inside that turn —
+        // exposed as a diagnostic under `copilot` rather than masquerading
+        // as `llmRequests` (which the CLI renders as the billing indicator).
+        usageNode.put("llmRequests", 1);
         // Phase 1 diagnostics: expose the per-session premium counter so the TUI /
         // logs make the 1-request-per-sendAndWait claim observable.
         var copilotNode = objectMapper.createObjectNode();

--- a/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/StreamingAgentHandler.java
+++ b/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/StreamingAgentHandler.java
@@ -43,6 +43,7 @@ import dev.acecopilot.core.planner.SequentialPlanExecutor;
 import dev.acecopilot.core.planner.StepResult;
 import dev.acecopilot.core.planner.StepStatus;
 import dev.acecopilot.core.planner.TaskPlan;
+import dev.acecopilot.llm.copilot.CopilotAcpClient;
 import dev.acecopilot.memory.AutoMemoryStore;
 import dev.acecopilot.memory.CandidatePromptAssembler;
 import dev.acecopilot.memory.CandidateStore;
@@ -167,6 +168,15 @@ public final class StreamingAgentHandler {
     private final ConcurrentHashMap<String, ReentrantLock> sessionTurnLocks =
             new ConcurrentHashMap<>();
 
+    // --- Copilot SDK sessionful runtime (Phase 1, issue #3) ---------------
+    // One sidecar per ace-copilot session. Lazily created on first prompt
+    // that takes the session path; torn down in clearSessionMetrics.
+    private final ConcurrentHashMap<String, CopilotAcpClient> sessionSidecars =
+            new ConcurrentHashMap<>();
+    private volatile String copilotRuntime = "chat";
+    private volatile String copilotGithubToken;
+    private volatile Path copilotSidecarDir;
+
 
     /**
      * Creates a streaming agent handler.
@@ -287,6 +297,17 @@ public final class StreamingAgentHandler {
         try {
             // Start the cancel monitor thread to read from the socket
             cancelContext.startMonitor();
+
+            // Phase 1 (issue #3): Route the entire prompt through the Copilot SDK
+            // sessionful runtime. The SDK agent handles its own ReAct loop inside
+            // one sendAndWait, billing as 1 premium_interactions.usedRequests
+            // regardless of internal tool / LLM iterations. Bypasses this handler's
+            // ReAct loop, planner, compaction, tool registry, and permission model
+            // — those integrate in Phase 2+ (issues #4, #5).
+            if ("session".equalsIgnoreCase(copilotRuntime) && "copilot".equalsIgnoreCase(provider)) {
+                return handlePromptViaCopilotSession(
+                        sessionId, session, prompt, cancelContext, cancellationToken);
+            }
 
             // Check for resumable plan checkpoint before planning or execution
             if (planCheckpointStore != null) {
@@ -1517,6 +1538,25 @@ public final class StreamingAgentHandler {
     }
 
     /**
+     * Configures the Copilot SDK sessionful runtime (issue #3, Phase 1).
+     *
+     * @param runtime      {@code "chat"} (default, legacy {@code /chat/completions} path) or
+     *                     {@code "session"} (route user prompts through Node sidecar → SDK session)
+     * @param githubToken  raw GitHub OAuth/PAT for the SDK to exchange; may be {@code null}
+     *                     to let the SDK discover credentials from the logged-in {@code gh} user
+     * @param sidecarDir   directory containing {@code sidecar.mjs} and installed
+     *                     {@code node_modules} (typically {@code <repo>/ace-copilot-sidecar/})
+     */
+    public void setCopilotRuntimeConfig(String runtime, String githubToken, Path sidecarDir) {
+        this.copilotRuntime = (runtime != null && !runtime.isBlank()) ? runtime : "chat";
+        this.copilotGithubToken = githubToken;
+        this.copilotSidecarDir = sidecarDir;
+        log.info("Copilot runtime: runtime={}, sidecarDir={}, token={}",
+                this.copilotRuntime, sidecarDir,
+                (githubToken != null && !githubToken.isBlank()) ? "(set)" : "(logged-in user)");
+    }
+
+    /**
      * Sets the MCP initialization future so request-time code can await readiness.
      */
     public void setMcpInitFuture(CompletableFuture<Void> mcpInitFuture) {
@@ -1756,6 +1796,132 @@ public final class StreamingAgentHandler {
         sessionProgressDetectors.remove(sessionId);
         sessionPostProcessing.remove(sessionId);
         sessionRuntimePruneScheduled.remove(sessionId);
+        closeSessionSidecar(sessionId);
+    }
+
+    private void closeSessionSidecar(String sessionId) {
+        var client = sessionSidecars.remove(sessionId);
+        if (client == null) return;
+        try {
+            client.close();
+        } catch (RuntimeException e) {
+            log.warn("Copilot sidecar close failed for session {}: {}", sessionId, e.getMessage());
+        }
+    }
+
+    /**
+     * Phase 1 dispatch for the Copilot SDK sessionful runtime (issue #3).
+     *
+     * <p>Delegates one user prompt to {@link CopilotAcpClient#sendAndWait} on the
+     * per-session sidecar. Streams assistant text to the TUI via {@code stream.text}
+     * notifications. Records the assistant's final message on the session history.
+     *
+     * <p>Known limitations (deferred to later phases):
+     * <ul>
+     *   <li>SDK agent uses its own built-in tools, not ace-copilot's 6 tools (Phase 2, #4)</li>
+     *   <li>SDK agent auto-approves its permissions (sidecar uses {@code approveAll}) —
+     *       filesystem / shell side effects bypass {@link PermissionManager} (Phase 2, #4)</li>
+     *   <li>No {@code respondToUserInput} routing — follow-up messages are new
+     *       {@code sendAndWait} calls (Phase 3, #5)</li>
+     *   <li>No planner / self-improvement / checkpoint / compaction hooks</li>
+     *   <li>Cancellation mid-call is best-effort: the request returns after the
+     *       sendAndWait finishes; cancel has no wire-level interrupt yet</li>
+     * </ul>
+     */
+    private Object handlePromptViaCopilotSession(String sessionId,
+                                                 AgentSession session,
+                                                 String prompt,
+                                                 CancelAwareStreamContext cancelContext,
+                                                 CancellationToken cancellationToken)
+            throws Exception {
+        if (copilotSidecarDir == null) {
+            throw new IllegalStateException(
+                    "copilotRuntime=session requires a sidecar directory. "
+                            + "Set ACE_COPILOT_SIDECAR_DIR or configure at daemon startup.");
+        }
+
+        session.addMessage(new AgentSession.ConversationMessage.User(prompt));
+
+        String model = getModelForSession(sessionId);
+        if (model == null || model.isBlank()) model = "claude-haiku-4.5";
+
+        var client = sessionSidecars.computeIfAbsent(sessionId, _ -> {
+            try {
+                log.info("Launching Copilot sidecar for session {}", sessionId);
+                return new CopilotAcpClient(copilotSidecarDir, copilotGithubToken);
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to launch Copilot sidecar: " + e.getMessage(), e);
+            }
+        });
+
+        var started = System.currentTimeMillis();
+        var textBuf = new StringBuilder();
+        CopilotAcpClient.SendResult r;
+        try {
+            r = client.sendAndWait(model, prompt, (delta) -> {
+                if (delta == null || delta.isEmpty()) return;
+                textBuf.append(delta);
+                try {
+                    var p = objectMapper.createObjectNode();
+                    p.put("delta", delta);
+                    cancelContext.sendNotification("stream.text", p);
+                } catch (IOException e) {
+                    log.warn("Failed to forward stream.text: {}", e.getMessage());
+                }
+            });
+        } catch (IOException e) {
+            closeSessionSidecar(sessionId);
+            throw new IllegalStateException("Copilot session runtime failed: " + e.getMessage(), e);
+        }
+
+        String responseText = r.content() != null ? r.content() : textBuf.toString();
+        if (responseText != null && !responseText.isBlank()) {
+            session.addMessage(new AgentSession.ConversationMessage.Assistant(responseText));
+        }
+
+        sendCancelledNotificationIfNeeded(cancellationToken, cancelContext, sessionId);
+
+        var result = objectMapper.createObjectNode();
+        result.put("sessionId", sessionId);
+        result.put("response", responseText != null ? responseText : "");
+        result.put("stopReason", r.stopReason() != null ? r.stopReason() : "COMPLETE");
+        if (cancellationToken.isCancelled()) result.put("cancelled", true);
+
+        var usageNode = objectMapper.createObjectNode();
+        var first = r.firstUsage();
+        var last = r.lastUsage();
+        if (last != null) {
+            if (last.inputTokens() != null) usageNode.put("inputTokens", last.inputTokens());
+            if (last.outputTokens() != null) usageNode.put("outputTokens", last.outputTokens());
+            if (last.inputTokens() != null && last.outputTokens() != null) {
+                usageNode.put("totalTokens", last.inputTokens() + last.outputTokens());
+            }
+        }
+        usageNode.put("llmRequests", r.usageEventCount());
+        // Phase 1 diagnostics: expose the per-session premium counter so the TUI /
+        // logs make the 1-request-per-sendAndWait claim observable.
+        var copilotNode = objectMapper.createObjectNode();
+        copilotNode.put("runtime", "session");
+        copilotNode.put("usageEventCount", r.usageEventCount());
+        if (first != null && first.premiumUsed() != null) {
+            copilotNode.put("premiumUsedBefore", first.premiumUsed());
+            copilotNode.put("initiatorFirst", first.initiator());
+        }
+        if (last != null && last.premiumUsed() != null) {
+            copilotNode.put("premiumUsedAfter", last.premiumUsed());
+            copilotNode.put("initiatorLast", last.initiator());
+        }
+        copilotNode.put("premiumDelta", r.premiumDelta());
+        copilotNode.put("wallMs", System.currentTimeMillis() - started);
+        usageNode.set("copilot", copilotNode);
+        result.set("usage", usageNode);
+
+        log.info(
+                "Copilot session turn: sessionId={}, model={}, premiumDelta={}, usageEvents={}, wallMs={}",
+                sessionId, model, r.premiumDelta(), r.usageEventCount(),
+                System.currentTimeMillis() - started);
+
+        return result;
     }
 
     public void awaitSessionPostProcessing(String sessionId) {

--- a/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/StreamingAgentHandler.java
+++ b/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/StreamingAgentHandler.java
@@ -1950,8 +1950,11 @@ public final class StreamingAgentHandler {
         result.set("usage", usageNode);
 
         log.info(
-                "Copilot session turn: sessionId={}, model={}, premiumDelta={}, usageEvents={}, wallMs={}",
-                sessionId, model, r.premiumDelta(), r.usageEventCount(),
+                "Copilot session turn: sessionId={}, model={}, premiumUsed={}->{} (delta={}), usageEvents={}, wallMs={}",
+                sessionId, model,
+                first != null && first.premiumUsed() != null ? first.premiumUsed() : "?",
+                last != null && last.premiumUsed() != null ? last.premiumUsed() : "?",
+                r.premiumDelta(), r.usageEventCount(),
                 System.currentTimeMillis() - started);
 
         return result;

--- a/ace-copilot-daemon/src/test/java/dev/acecopilot/daemon/AceCopilotConfigTest.java
+++ b/ace-copilot-daemon/src/test/java/dev/acecopilot/daemon/AceCopilotConfigTest.java
@@ -24,11 +24,21 @@ class AceCopilotConfigTest {
     // -- applyKeychainCredential tests --
 
     /**
-     * Creates a config with a dummy provider so that load() does NOT trigger
-     * real Keychain credential discovery. We test applyKeychainCredential() in isolation.
+     * Creates a truly blank config by invoking the private no-arg constructor
+     * directly. We can't use {@code load()} here: it reads the user's real
+     * {@code ~/.ace-copilot/config.json}, which may populate fields like
+     * {@code apiKey} (e.g. users who configured a Copilot gho_ token on the
+     * active profile) and break the assumption that a fresh config has nothing
+     * set. applyKeychainCredential is tested in isolation.
      */
     private static AceCopilotConfig blankConfig() {
-        return AceCopilotConfig.load(null, "test-dummy");
+        try {
+            var ctor = AceCopilotConfig.class.getDeclaredConstructor();
+            ctor.setAccessible(true);
+            return ctor.newInstance();
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("AceCopilotConfig no-arg constructor changed unexpectedly", e);
+        }
     }
 
     private static KeychainCredentialReader.Credential freshCredential(

--- a/ace-copilot-daemon/src/test/java/dev/acecopilot/daemon/CopilotRuntimeGateTest.java
+++ b/ace-copilot-daemon/src/test/java/dev/acecopilot/daemon/CopilotRuntimeGateTest.java
@@ -1,0 +1,88 @@
+package dev.acecopilot.daemon;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Truth-table coverage for the {@link AceCopilotConfig#effectiveCopilotRuntime()}
+ * safety gate (Phase 1, issue #3). The gate must collapse misconfigured
+ * session-without-ack back to {@code "chat"}; this is the only thing
+ * standing between a mistyped config and a PermissionManager bypass, so
+ * it is worth a unit test even though the rest of the session runtime
+ * is covered by integration tests.
+ */
+class CopilotRuntimeGateTest {
+
+    @Test
+    void defaultsToChat() throws Exception {
+        var config = blankConfig();
+        assertThat(config.copilotRuntime()).isEqualTo("chat");
+        assertThat(config.copilotRuntimeAcceptUnsandboxed()).isFalse();
+        assertThat(config.effectiveCopilotRuntime()).isEqualTo("chat");
+    }
+
+    @Test
+    void sessionWithoutAckFallsBackToChat() throws Exception {
+        var config = blankConfig();
+        setField(config, "copilotRuntime", "session");
+        setField(config, "copilotRuntimeAcceptUnsandboxed", false);
+
+        assertThat(config.copilotRuntime()).isEqualTo("session");
+        assertThat(config.effectiveCopilotRuntime())
+                .as("session mode must refuse to activate without explicit ack")
+                .isEqualTo("chat");
+    }
+
+    @Test
+    void ackWithoutSessionStillChat() throws Exception {
+        var config = blankConfig();
+        setField(config, "copilotRuntime", "chat");
+        setField(config, "copilotRuntimeAcceptUnsandboxed", true);
+
+        assertThat(config.effectiveCopilotRuntime())
+                .as("ack flag alone must not promote chat to session")
+                .isEqualTo("chat");
+    }
+
+    @Test
+    void sessionPlusAckActivates() throws Exception {
+        var config = blankConfig();
+        setField(config, "copilotRuntime", "session");
+        setField(config, "copilotRuntimeAcceptUnsandboxed", true);
+
+        assertThat(config.effectiveCopilotRuntime())
+                .as("both flags true is the one combination that activates session")
+                .isEqualTo("session");
+    }
+
+    @Test
+    void sessionLiteralIsCaseInsensitive() throws Exception {
+        var config = blankConfig();
+        setField(config, "copilotRuntime", "SESSION");
+        setField(config, "copilotRuntimeAcceptUnsandboxed", true);
+
+        assertThat(config.effectiveCopilotRuntime()).isEqualTo("session");
+    }
+
+    /**
+     * Constructs {@link AceCopilotConfig} directly (bypassing
+     * {@link AceCopilotConfig#load}) so the test is insulated from the
+     * developer's real {@code ~/.ace-copilot/config.json}, which may
+     * already set {@code copilotRuntime="session"} for manual testing.
+     */
+    private static AceCopilotConfig blankConfig() throws Exception {
+        Constructor<AceCopilotConfig> ctor = AceCopilotConfig.class.getDeclaredConstructor();
+        ctor.setAccessible(true);
+        return ctor.newInstance();
+    }
+
+    private static void setField(Object target, String name, Object value) throws Exception {
+        Field f = AceCopilotConfig.class.getDeclaredField(name);
+        f.setAccessible(true);
+        f.set(target, value);
+    }
+}

--- a/ace-copilot-llm/build.gradle.kts
+++ b/ace-copilot-llm/build.gradle.kts
@@ -6,4 +6,19 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-databind")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     implementation("org.slf4j:slf4j-api")
+
+    runtimeOnly("ch.qos.logback:logback-classic")
+}
+
+// Phase 1 (issue #3) manual verification harness for CopilotAcpClient.
+// Run: ACE_COPILOT_GH_ACCOUNT=<gh-acct> ./gradlew :ace-copilot-llm:runCopilotAcpMain
+tasks.register<JavaExec>("runCopilotAcpMain") {
+    group = "verification"
+    description = "Manual verification for CopilotAcpClient (spawns the Node sidecar, runs one sendAndWait)"
+    mainClass.set("dev.acecopilot.llm.copilot.CopilotAcpClientMain")
+    classpath = sourceSets.main.get().runtimeClasspath
+    jvmArgs = listOf("--enable-preview")
+    standardInput = System.`in`
+    // Run from repo root so the default sidecarDir resolves correctly.
+    workingDir = rootProject.projectDir
 }

--- a/ace-copilot-llm/src/main/java/dev/acecopilot/llm/copilot/CopilotAcpClient.java
+++ b/ace-copilot-llm/src/main/java/dev/acecopilot/llm/copilot/CopilotAcpClient.java
@@ -1,0 +1,351 @@
+package dev.acecopilot.llm.copilot;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+
+/**
+ * Client for the ace-copilot Copilot SDK sidecar ({@code ace-copilot-sidecar/sidecar.mjs}).
+ *
+ * <p>Launches the Node subprocess, speaks LSP-framed JSON-RPC over stdio, and
+ * exposes a single agent turn as a Java method. Each {@link #sendAndWait} call
+ * maps to one Copilot SDK {@code session.sendAndWait} — billed as exactly one
+ * {@code premium_interactions.usedRequests} regardless of how many internal
+ * ReAct iterations or tool calls happen inside it.
+ *
+ * <p>Not a {@code LlmClient} — the semantics are different. The SDK agent runs
+ * its own internal ReAct loop inside one call, whereas {@code LlmClient} is
+ * request-response at the LLM layer.
+ *
+ * <p>This is the Phase 1 skeleton (issue #3): no tool registration, no
+ * {@code respondToUserInput} routing, no {@code LlmClientFactory} wiring.
+ * It is callable from Java but not yet reached by a user prompt through the
+ * daemon agent loop.
+ */
+public final class CopilotAcpClient implements AutoCloseable {
+
+    private static final Logger log = LoggerFactory.getLogger(CopilotAcpClient.class);
+
+    /** Notification emitted by the sidecar during {@code session.sendAndWait}. */
+    public record NotificationEvent(String method, JsonNode params) {}
+
+    /** Single {@code assistant.usage} sample. */
+    public record UsageSnapshot(
+            String model,
+            Long inputTokens,
+            Long outputTokens,
+            Double cost,
+            String initiator,
+            Long premiumUsed,
+            Long premiumLimit
+    ) {}
+
+    /** Final result of one {@link #sendAndWait}. */
+    public record SendResult(
+            String content,
+            String stopReason,
+            UsageSnapshot firstUsage,
+            UsageSnapshot lastUsage,
+            int usageEventCount
+    ) {
+        /** Change in {@code premium_interactions.usedRequests} across this turn. */
+        public long premiumDelta() {
+            if (firstUsage == null || lastUsage == null) return -1;
+            if (firstUsage.premiumUsed == null || lastUsage.premiumUsed == null) return -1;
+            return lastUsage.premiumUsed - firstUsage.premiumUsed;
+        }
+    }
+
+    private final Process sidecar;
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final AtomicLong nextId = new AtomicLong(1);
+    private final ConcurrentMap<Long, CompletableFuture<JsonNode>> pending = new ConcurrentHashMap<>();
+    private final Thread readerThread;
+    private volatile Consumer<NotificationEvent> notificationHandler;
+
+    /**
+     * Launches the sidecar located at {@code sidecarDir/sidecar.mjs} and
+     * completes the {@code initialize} handshake.
+     *
+     * @param sidecarDir  directory containing {@code sidecar.mjs} and installed
+     *                    {@code node_modules} (typically {@code ace-copilot-sidecar/})
+     * @param githubToken GitHub token passed to the SDK; may be {@code null} to
+     *                    let the SDK discover credentials from the logged-in
+     *                    {@code gh} user. Resolve upstream via
+     *                    {@code CopilotTokenProvider}.
+     */
+    public CopilotAcpClient(Path sidecarDir, String githubToken) throws IOException {
+        Objects.requireNonNull(sidecarDir, "sidecarDir");
+        var script = sidecarDir.resolve("sidecar.mjs").toAbsolutePath();
+        var pb = new ProcessBuilder("node", script.toString())
+                .directory(sidecarDir.toFile())
+                .redirectErrorStream(false);
+        log.info("Launching Copilot sidecar: {}", script);
+        this.sidecar = pb.start();
+
+        this.readerThread = new Thread(this::readLoop, "copilot-sidecar-reader");
+        readerThread.setDaemon(true);
+        readerThread.start();
+
+        var errThread = new Thread(() -> {
+            try (var br = new BufferedReader(new InputStreamReader(
+                    sidecar.getErrorStream(), StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = br.readLine()) != null) {
+                    log.info("sidecar: {}", line);
+                }
+            } catch (IOException e) {
+                log.debug("sidecar stderr closed", e);
+            }
+        }, "copilot-sidecar-stderr");
+        errThread.setDaemon(true);
+        errThread.start();
+
+        try {
+            ObjectNode initParams = mapper.createObjectNode();
+            if (githubToken != null && !githubToken.isBlank()) {
+                initParams.put("githubToken", githubToken);
+            }
+            JsonNode init = request("initialize", initParams).get(30, TimeUnit.SECONDS);
+            log.info("Sidecar initialized, protocolVersion={}", init.path("protocolVersion").asText());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            destroy();
+            throw new IOException("sidecar initialize interrupted", e);
+        } catch (ExecutionException | TimeoutException e) {
+            destroy();
+            throw new IOException("sidecar initialize failed", e);
+        }
+    }
+
+    /**
+     * Issues a single agent turn to the Copilot SDK and blocks until it
+     * completes. Text deltas and usage snapshots emitted during the turn are
+     * forwarded to the supplied consumers.
+     *
+     * @param model     model identifier to pass to {@code createSession}
+     * @param prompt    user prompt text
+     * @param textDelta optional consumer invoked for each text delta chunk;
+     *                  may be {@code null} to drop text
+     * @return final assistant content, stop reason, and first/last usage snapshots
+     */
+    public SendResult sendAndWait(String model, String prompt, Consumer<String> textDelta) throws IOException {
+        Objects.requireNonNull(model, "model");
+        Objects.requireNonNull(prompt, "prompt");
+
+        var accum = new Object() {
+            UsageSnapshot firstUsage;
+            UsageSnapshot lastUsage;
+            int usageCount;
+        };
+
+        this.notificationHandler = (n) -> {
+            switch (n.method()) {
+                case "session/text" -> {
+                    var d = n.params().path("delta").asText(null);
+                    if (d != null && textDelta != null) {
+                        try { textDelta.accept(d); }
+                        catch (RuntimeException e) { log.warn("textDelta consumer threw", e); }
+                    }
+                }
+                case "session/usage" -> {
+                    var u = readUsage(n.params());
+                    if (accum.firstUsage == null) accum.firstUsage = u;
+                    accum.lastUsage = u;
+                    accum.usageCount++;
+                }
+                default -> log.debug("ignored notification: {}", n.method());
+            }
+        };
+
+        try {
+            ObjectNode params = mapper.createObjectNode();
+            params.put("model", model);
+            params.put("prompt", prompt);
+            JsonNode resp = request("session.sendAndWait", params).get(10, TimeUnit.MINUTES);
+            String content = resp.path("content").isNull() ? null : resp.path("content").asText(null);
+            String stopReason = resp.path("stopReason").isNull() ? null : resp.path("stopReason").asText(null);
+            return new SendResult(content, stopReason, accum.firstUsage, accum.lastUsage, accum.usageCount);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("sendAndWait interrupted", e);
+        } catch (ExecutionException | TimeoutException e) {
+            throw new IOException("sendAndWait failed: " + e.getMessage(), e);
+        } finally {
+            this.notificationHandler = null;
+        }
+    }
+
+    private UsageSnapshot readUsage(JsonNode p) {
+        return new UsageSnapshot(
+                optText(p, "model"),
+                optLong(p, "inputTokens"),
+                optLong(p, "outputTokens"),
+                optDouble(p, "cost"),
+                optText(p, "initiator"),
+                optLong(p, "premiumUsed"),
+                optLong(p, "premiumLimit")
+        );
+    }
+
+    private static String optText(JsonNode p, String f) {
+        var n = p.get(f);
+        return (n == null || n.isNull()) ? null : n.asText();
+    }
+
+    private static Long optLong(JsonNode p, String f) {
+        var n = p.get(f);
+        return (n == null || n.isNull()) ? null : n.asLong();
+    }
+
+    private static Double optDouble(JsonNode p, String f) {
+        var n = p.get(f);
+        return (n == null || n.isNull()) ? null : n.asDouble();
+    }
+
+    private CompletableFuture<JsonNode> request(String method, Object params) {
+        long id = nextId.getAndIncrement();
+        var future = new CompletableFuture<JsonNode>();
+        pending.put(id, future);
+        try {
+            ObjectNode req = mapper.createObjectNode();
+            req.put("jsonrpc", "2.0");
+            req.put("id", id);
+            req.put("method", method);
+            if (params != null) req.set("params", mapper.valueToTree(params));
+            writeMessage(req);
+        } catch (IOException e) {
+            pending.remove(id);
+            future.completeExceptionally(e);
+        }
+        return future;
+    }
+
+    private synchronized void writeMessage(JsonNode msg) throws IOException {
+        byte[] body = mapper.writeValueAsBytes(msg);
+        OutputStream out = sidecar.getOutputStream();
+        out.write(("Content-Length: " + body.length + "\r\n\r\n").getBytes(StandardCharsets.US_ASCII));
+        out.write(body);
+        out.flush();
+    }
+
+    private void readLoop() {
+        try (var in = new BufferedInputStream(sidecar.getInputStream())) {
+            while (true) {
+                int contentLength = readHeader(in);
+                if (contentLength < 0) break;
+                byte[] body = in.readNBytes(contentLength);
+                if (body.length < contentLength) {
+                    log.warn("truncated body: got {} of {} bytes", body.length, contentLength);
+                    break;
+                }
+                JsonNode msg = mapper.readTree(body);
+                handleIncoming(msg);
+            }
+        } catch (IOException e) {
+            log.debug("sidecar reader terminated: {}", e.getMessage());
+        } finally {
+            var closeErr = new IOException("sidecar closed");
+            pending.values().forEach(f -> f.completeExceptionally(closeErr));
+            pending.clear();
+        }
+    }
+
+    private int readHeader(InputStream in) throws IOException {
+        var line = new StringBuilder();
+        int contentLength = -1;
+        while (true) {
+            int ch;
+            line.setLength(0);
+            while ((ch = in.read()) != -1 && ch != '\r') {
+                line.append((char) ch);
+            }
+            if (ch == -1) return -1;
+            int nl = in.read();
+            if (nl != '\n') throw new IOException("malformed header framing");
+            if (line.length() == 0) break;
+            String h = line.toString();
+            int colon = h.indexOf(':');
+            if (colon > 0 && "Content-Length".equalsIgnoreCase(h.substring(0, colon).trim())) {
+                try {
+                    contentLength = Integer.parseInt(h.substring(colon + 1).trim());
+                } catch (NumberFormatException e) {
+                    throw new IOException("invalid Content-Length: " + h, e);
+                }
+            }
+        }
+        return contentLength;
+    }
+
+    private void handleIncoming(JsonNode msg) {
+        if (msg.has("id") && (msg.has("result") || msg.has("error"))) {
+            long id = msg.get("id").asLong();
+            var fut = pending.remove(id);
+            if (fut == null) {
+                log.warn("no pending request for response id={}", id);
+                return;
+            }
+            if (msg.has("error")) {
+                fut.completeExceptionally(new RuntimeException(
+                        "sidecar error: " + msg.get("error").toString()));
+            } else {
+                fut.complete(msg.get("result"));
+            }
+        } else if (msg.has("method")) {
+            var h = notificationHandler;
+            if (h != null) {
+                try {
+                    h.accept(new NotificationEvent(
+                            msg.get("method").asText(),
+                            msg.has("params") ? msg.get("params") : mapper.createObjectNode()));
+                } catch (RuntimeException e) {
+                    log.warn("notification handler threw", e);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void close() {
+        try {
+            request("shutdown", null).get(5, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            log.debug("shutdown request did not complete cleanly: {}", e.getMessage());
+        }
+        destroy();
+    }
+
+    private void destroy() {
+        if (sidecar.isAlive()) {
+            sidecar.destroy();
+            try {
+                if (!sidecar.waitFor(3, TimeUnit.SECONDS)) {
+                    sidecar.destroyForcibly();
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                sidecar.destroyForcibly();
+            }
+        }
+    }
+}

--- a/ace-copilot-llm/src/main/java/dev/acecopilot/llm/copilot/CopilotAcpClient.java
+++ b/ace-copilot-llm/src/main/java/dev/acecopilot/llm/copilot/CopilotAcpClient.java
@@ -101,7 +101,15 @@ public final class CopilotAcpClient implements AutoCloseable {
                 .directory(sidecarDir.toFile())
                 .redirectErrorStream(false);
         log.info("Launching Copilot sidecar: {}", script);
-        this.sidecar = pb.start();
+        try {
+            this.sidecar = pb.start();
+        } catch (IOException e) {
+            throw new IOException(
+                    "Failed to launch Copilot sidecar: " + e.getMessage()
+                    + ". copilotRuntime=session requires Node.js on PATH — install Node.js 20+"
+                    + " (https://nodejs.org/) and restart the daemon, or set copilotRuntime back to 'chat'.",
+                    e);
+        }
 
         this.readerThread = new Thread(this::readLoop, "copilot-sidecar-reader");
         readerThread.setDaemon(true);

--- a/ace-copilot-llm/src/main/java/dev/acecopilot/llm/copilot/CopilotAcpClientMain.java
+++ b/ace-copilot-llm/src/main/java/dev/acecopilot/llm/copilot/CopilotAcpClientMain.java
@@ -1,0 +1,131 @@
+package dev.acecopilot.llm.copilot;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Manual verification harness for {@link CopilotAcpClient} (Phase 1, issue #3).
+ *
+ * <p>Run from the repo root:
+ * <pre>
+ *   ./gradlew :ace-copilot-llm:compileJava
+ *   java --enable-preview -cp "$(./gradlew -q :ace-copilot-llm:printRuntimeClasspath)" \
+ *     dev.acecopilot.llm.copilot.CopilotAcpClientMain
+ * </pre>
+ *
+ * <p>Or more simply, since the daemon already has the classpath wired up:
+ * <pre>
+ *   ACE_COPILOT_GH_ACCOUNT=xinhua-gu_acncp \
+ *     ./ace-copilot-cli/build/install/ace-copilot-cli/bin/ace-copilot-cli \
+ *     --main dev.acecopilot.llm.copilot.CopilotAcpClientMain
+ * </pre>
+ *
+ * <p>Picks up configuration from env vars (in priority order):
+ * <ul>
+ *   <li>{@code ACE_COPILOT_SIDECAR_DIR} — path to {@code ace-copilot-sidecar/} (default: repo-relative)</li>
+ *   <li>{@code ACE_COPILOT_COPILOT_MODEL} — model to use (default: {@code claude-haiku-4.5})</li>
+ *   <li>{@code ACE_COPILOT_COPILOT_PROMPT} — prompt to send (default: a built-in tool-exercising prompt)</li>
+ *   <li>{@code ACE_COPILOT_GITHUB_TOKEN} — explicit token, if set</li>
+ *   <li>{@code ACE_COPILOT_GH_ACCOUNT} — gh account name to resolve token via {@code gh auth token --user <acct>}</li>
+ * </ul>
+ */
+public final class CopilotAcpClientMain {
+
+    private static final String DEFAULT_MODEL = "claude-haiku-4.5";
+
+    private static final String DEFAULT_PROMPT = """
+            List the top-level files in the current directory and tell me, in one sentence,
+            what kind of project this looks like. Use your tools — do not guess.
+            """;
+
+    private CopilotAcpClientMain() {}
+
+    public static void main(String[] args) throws IOException {
+        Path sidecarDir = resolveSidecarDir();
+        if (!Files.exists(sidecarDir.resolve("sidecar.mjs"))) {
+            System.err.println("sidecar.mjs not found under " + sidecarDir.toAbsolutePath());
+            System.err.println("Set ACE_COPILOT_SIDECAR_DIR to the ace-copilot-sidecar/ directory.");
+            System.exit(2);
+        }
+        if (!Files.exists(sidecarDir.resolve("node_modules"))) {
+            System.err.println("node_modules not installed at " + sidecarDir.toAbsolutePath());
+            System.err.println("Run: (cd " + sidecarDir + " && npm install)");
+            System.exit(2);
+        }
+
+        String model = envOrDefault("ACE_COPILOT_COPILOT_MODEL", DEFAULT_MODEL);
+        String prompt = envOrDefault("ACE_COPILOT_COPILOT_PROMPT", DEFAULT_PROMPT).trim();
+        String token = resolveGithubToken();
+
+        System.out.println("[main] sidecarDir: " + sidecarDir.toAbsolutePath());
+        System.out.println("[main] model:      " + model);
+        System.out.println("[main] token:      " + (token != null ? "(resolved, len=" + token.length() + ")" : "(null, SDK will use logged-in user)"));
+        System.out.println("[main] prompt:     " + prompt.replaceAll("\\s+", " "));
+        System.out.println();
+
+        long started = System.currentTimeMillis();
+        try (var client = new CopilotAcpClient(sidecarDir, token)) {
+            System.out.println("[main] sending...");
+            System.out.print("[assistant] ");
+            var result = client.sendAndWait(model, prompt, System.out::print);
+            System.out.println();
+            System.out.println();
+            System.out.println("[main] ---------- RESULT ----------");
+            System.out.println("  stopReason:             " + result.stopReason());
+            System.out.println("  usage events:           " + result.usageEventCount());
+            if (result.firstUsage() != null) {
+                System.out.println("  first usage initiator:  " + result.firstUsage().initiator());
+                System.out.println("  first usage premium:    " + result.firstUsage().premiumUsed());
+            }
+            if (result.lastUsage() != null) {
+                System.out.println("  last usage initiator:   " + result.lastUsage().initiator());
+                System.out.println("  last usage premium:     " + result.lastUsage().premiumUsed());
+            }
+            System.out.println("  premium delta (session):" + result.premiumDelta());
+            System.out.println("  wall clock:             " + (System.currentTimeMillis() - started) + "ms");
+            if (result.premiumDelta() == 0 && result.usageEventCount() > 1) {
+                System.out.println("  note: delta 0 across multiple usage events is expected when");
+                System.out.println("        the first reported count is post-increment (see probe-usage.mjs).");
+                System.out.println("        Run twice back-to-back to see the between-sessions +1.");
+            }
+        }
+    }
+
+    private static Path resolveSidecarDir() {
+        String env = System.getenv("ACE_COPILOT_SIDECAR_DIR");
+        if (env != null && !env.isBlank()) return Path.of(env);
+        return Path.of("ace-copilot-sidecar").toAbsolutePath();
+    }
+
+    private static String envOrDefault(String name, String fallback) {
+        String v = System.getenv(name);
+        return (v != null && !v.isBlank()) ? v : fallback;
+    }
+
+    private static String resolveGithubToken() {
+        String explicit = System.getenv("ACE_COPILOT_GITHUB_TOKEN");
+        if (explicit != null && !explicit.isBlank()) return explicit.trim();
+        String ghAccount = System.getenv("ACE_COPILOT_GH_ACCOUNT");
+        if (ghAccount == null || ghAccount.isBlank()) return null;
+        try {
+            var pb = new ProcessBuilder("gh", "auth", "token", "--user", ghAccount);
+            pb.redirectErrorStream(true);
+            Process p = pb.start();
+            String out;
+            try (var r = new BufferedReader(new InputStreamReader(p.getInputStream(), StandardCharsets.UTF_8))) {
+                out = r.readLine();
+            }
+            int exit = p.waitFor();
+            if (exit == 0 && out != null && !out.isBlank()) return out.trim();
+            System.err.println("[main] gh auth token --user " + ghAccount + " failed (exit=" + exit + ")");
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) Thread.currentThread().interrupt();
+            System.err.println("[main] could not resolve gh token: " + e.getMessage());
+        }
+        return null;
+    }
+}

--- a/ace-copilot-llm/src/main/java/dev/acecopilot/llm/copilot/session/CopilotSessionEvent.java
+++ b/ace-copilot-llm/src/main/java/dev/acecopilot/llm/copilot/session/CopilotSessionEvent.java
@@ -1,0 +1,83 @@
+package dev.acecopilot.llm.copilot.session;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Session-internal UI events emitted by the GitHub Copilot SDK / CLI ACP
+ * runtime when the agent needs to ask the user something from inside an
+ * existing session, instead of requiring a new external prompt.
+ *
+ * <p>Modeled after the {@code user_input.requested} and
+ * {@code elicitation.requested} events documented in the Copilot SDK
+ * ({@code github/copilot-sdk docs/features/streaming-events.md}). These are
+ * distinct from {@link dev.acecopilot.core.llm.StreamEvent} which represents
+ * LLM content deltas — session events sit at a different protocol layer.
+ *
+ * <p>Each event carries a {@link #requestId()} that must be echoed back via
+ * the corresponding {@link CopilotSessionResponse} to complete the exchange.
+ */
+public sealed interface CopilotSessionEvent
+        permits CopilotSessionEvent.UserInputRequested,
+                CopilotSessionEvent.ElicitationRequested {
+
+    /** Correlation identifier used to route the response back to the waiting agent. */
+    String requestId();
+
+    /**
+     * The agent is asking the user a free-form or choice-based question.
+     *
+     * @param requestId      correlation id — echo via {@link CopilotSessionResponse.UserInputResponse}
+     * @param question       prompt to present to the user
+     * @param choices        predefined selectable answers; empty list if not provided
+     * @param allowFreeform  whether arbitrary text input is accepted alongside any choices
+     */
+    record UserInputRequested(
+            String requestId,
+            String question,
+            List<String> choices,
+            boolean allowFreeform
+    ) implements CopilotSessionEvent {
+        public UserInputRequested {
+            requestId = Objects.requireNonNull(requestId, "requestId");
+            question = Objects.requireNonNull(question, "question");
+            choices = choices != null ? List.copyOf(choices) : List.of();
+        }
+    }
+
+    /**
+     * The agent needs structured form input (MCP elicitation protocol).
+     *
+     * @param requestId          correlation id — echo via {@link CopilotSessionResponse.ElicitationResponse}
+     * @param message            description of what information is needed
+     * @param mode               {@link ElicitationMode#FORM} for schema-driven input,
+     *                           {@link ElicitationMode#URL} for browser-based flows
+     * @param requestedSchema    JSON Schema describing the form fields (required when mode is FORM)
+     * @param elicitationSource  origin of the request (e.g. MCP server name); may be {@code null}
+     * @param url                browser URL when {@code mode} is {@link ElicitationMode#URL}; else {@code null}
+     */
+    record ElicitationRequested(
+            String requestId,
+            String message,
+            ElicitationMode mode,
+            JsonNode requestedSchema,
+            String elicitationSource,
+            String url
+    ) implements CopilotSessionEvent {
+        public ElicitationRequested {
+            requestId = Objects.requireNonNull(requestId, "requestId");
+            message = Objects.requireNonNull(message, "message");
+            mode = mode != null ? mode : ElicitationMode.FORM;
+        }
+    }
+
+    /** Elicitation presentation style. */
+    enum ElicitationMode {
+        /** Agent expects structured data conforming to {@code requestedSchema}. */
+        FORM,
+        /** Agent expects the user to complete a flow at an external URL. */
+        URL
+    }
+}

--- a/ace-copilot-llm/src/main/java/dev/acecopilot/llm/copilot/session/CopilotSessionResponse.java
+++ b/ace-copilot-llm/src/main/java/dev/acecopilot/llm/copilot/session/CopilotSessionResponse.java
@@ -1,0 +1,66 @@
+package dev.acecopilot.llm.copilot.session;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Client responses to {@link CopilotSessionEvent}s. Sending one of these back
+ * into the Copilot session completes the in-session exchange without counting
+ * as a new external prompt — the core mechanism evaluated by issue #1.
+ *
+ * <p>The variants correspond one-to-one with
+ * {@link CopilotSessionEvent.UserInputRequested} (answered via
+ * {@code session.respondToUserInput()}) and
+ * {@link CopilotSessionEvent.ElicitationRequested} (answered via
+ * {@code session.respondToElicitation()}) in the Copilot SDK.
+ */
+public sealed interface CopilotSessionResponse
+        permits CopilotSessionResponse.UserInputResponse,
+                CopilotSessionResponse.ElicitationResponse {
+
+    /** Must match the {@code requestId} of the originating event. */
+    String requestId();
+
+    /**
+     * Free-form or choice response to a {@link CopilotSessionEvent.UserInputRequested}.
+     *
+     * @param requestId correlation id from the originating event
+     * @param response  the user's answer (one of the offered {@code choices} or free text)
+     */
+    record UserInputResponse(String requestId, String response) implements CopilotSessionResponse {
+        public UserInputResponse {
+            requestId = Objects.requireNonNull(requestId, "requestId");
+            response = Objects.requireNonNull(response, "response");
+        }
+    }
+
+    /**
+     * Structured response to a {@link CopilotSessionEvent.ElicitationRequested}.
+     *
+     * @param requestId correlation id from the originating event
+     * @param action    user's disposition — accept, decline, or cancel
+     * @param content   populated data conforming to the requested schema when
+     *                  {@code action == ACCEPT}; empty map otherwise
+     */
+    record ElicitationResponse(
+            String requestId,
+            ElicitationAction action,
+            Map<String, Object> content
+    ) implements CopilotSessionResponse {
+        public ElicitationResponse {
+            requestId = Objects.requireNonNull(requestId, "requestId");
+            action = Objects.requireNonNull(action, "action");
+            content = content != null ? Map.copyOf(content) : Map.of();
+        }
+    }
+
+    /** User's disposition on an elicitation request. */
+    enum ElicitationAction {
+        /** User provided the data; {@code content} is populated. */
+        ACCEPT,
+        /** User explicitly refused to answer. */
+        DECLINE,
+        /** User cancelled the dialog without deciding. */
+        CANCEL
+    }
+}

--- a/ace-copilot-llm/src/main/java/dev/acecopilot/llm/openai/CopilotTokenProvider.java
+++ b/ace-copilot-llm/src/main/java/dev/acecopilot/llm/openai/CopilotTokenProvider.java
@@ -146,18 +146,34 @@ public final class CopilotTokenProvider implements Supplier<String> {
     }
 
     private List<String> collectTokenCandidates() {
+        return collectGithubTokenCandidates(configuredToken);
+    }
+
+    /**
+     * Returns the ordered list of GitHub token candidates using the same
+     * priority as the full Copilot auth resolution: cached OAuth →
+     * configured {@code apiKey} → {@code GITHUB_TOKEN} → {@code GH_TOKEN} →
+     * {@code gh auth token}. Exposed so consumers that need the raw GitHub
+     * token (e.g. the Copilot SDK sidecar, issue #3) can reuse this logic
+     * without triggering Copilot's token-exchange flow.
+     */
+    public static List<String> collectGithubTokenCandidates(String configuredToken) {
         List<String> candidates = new ArrayList<>(5);
-        // 0. Cached OAuth token from device-code flow (highest priority — known to work)
         addIfValid(candidates, CopilotDeviceAuth.loadCachedToken(), "cached OAuth token");
-        // 1. Configured token from config.json
         addIfValid(candidates, configuredToken, "config");
-        // 2. GITHUB_TOKEN env var
         addIfValid(candidates, System.getenv("GITHUB_TOKEN"), "GITHUB_TOKEN");
-        // 3. GH_TOKEN env var
         addIfValid(candidates, System.getenv("GH_TOKEN"), "GH_TOKEN");
-        // 4. gh auth token (GitHub CLI)
         addIfValid(candidates, resolveGhCliToken(), "gh CLI");
         return candidates;
+    }
+
+    /**
+     * Convenience wrapper around {@link #collectGithubTokenCandidates} that
+     * returns the first candidate, or {@code null} if none are available.
+     */
+    public static String firstGithubTokenCandidate(String configuredToken) {
+        var list = collectGithubTokenCandidates(configuredToken);
+        return list.isEmpty() ? null : list.getFirst();
     }
 
     private static void addIfValid(List<String> candidates, String token, String source) {

--- a/ace-copilot-llm/src/test/java/dev/acecopilot/llm/copilot/CopilotAcpClientSmokeTest.java
+++ b/ace-copilot-llm/src/test/java/dev/acecopilot/llm/copilot/CopilotAcpClientSmokeTest.java
@@ -1,0 +1,93 @@
+package dev.acecopilot.llm.copilot;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Smoke test for {@link CopilotAcpClient} covering the Phase 1 (issue #3)
+ * startup chain without touching the real Copilot backend.
+ *
+ * <p>Uses {@code src/test/resources/copilot/mock-sidecar.mjs} — a stripped
+ * sidecar that speaks the same LSP-framed JSON-RPC protocol but emits
+ * canned notifications and a fixed result. This exercises:
+ * <ul>
+ *   <li>subprocess spawn + initialize handshake</li>
+ *   <li>notification decoding ({@code session/text}, {@code session/usage})</li>
+ *   <li>usage snapshot first/last capture and premium delta</li>
+ *   <li>final {@code sendAndWait} response parsing</li>
+ *   <li>graceful {@code shutdown} + process teardown</li>
+ * </ul>
+ *
+ * <p>Skipped automatically when {@code node} is not on {@code PATH}; the
+ * session runtime itself is opt-in and guarded by a startup preflight in
+ * {@code AceCopilotDaemon}, so we do the same here to keep CI on machines
+ * without Node.js green.
+ */
+@EnabledIf("nodeAvailable")
+class CopilotAcpClientSmokeTest {
+
+    /** Used by {@link EnabledIf} to skip when Node.js is not installed. */
+    static boolean nodeAvailable() {
+        try {
+            var p = new ProcessBuilder("node", "--version").redirectErrorStream(true).start();
+            return p.waitFor() == 0;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @Test
+    void launchesSidecarHandshakesAndReportsUsage(@TempDir Path dir) throws IOException {
+        // CopilotAcpClient expects sidecarDir/sidecar.mjs — copy the mock
+        // out of resources so the file name matches.
+        copyResource("/copilot/mock-sidecar.mjs", dir.resolve("sidecar.mjs"));
+
+        var deltas = new ArrayList<String>();
+        CopilotAcpClient.SendResult result;
+
+        try (var client = new CopilotAcpClient(dir, null)) {
+            result = client.sendAndWait("test-model", "hi", deltas::add);
+        }
+
+        assertThat(deltas)
+                .as("both session/text deltas forwarded to consumer in order")
+                .containsExactly("Hello ", "world.");
+
+        assertThat(result.content()).isEqualTo("Hello world.");
+        assertThat(result.stopReason()).isEqualTo("COMPLETE");
+
+        assertThat(result.usageEventCount())
+                .as("both session/usage events captured")
+                .isEqualTo(2);
+
+        assertThat(result.firstUsage()).isNotNull();
+        assertThat(result.firstUsage().initiator()).isEqualTo("user");
+        assertThat(result.firstUsage().premiumUsed()).isEqualTo(42L);
+
+        assertThat(result.lastUsage()).isNotNull();
+        assertThat(result.lastUsage().initiator()).isEqualTo("agent");
+        assertThat(result.lastUsage().premiumUsed()).isEqualTo(43L);
+
+        assertThat(result.premiumDelta())
+                .as("delta = last - first, same field Phase 1 verification relies on")
+                .isEqualTo(1L);
+    }
+
+    private static void copyResource(String cp, Path dest) throws IOException {
+        try (InputStream in = CopilotAcpClientSmokeTest.class.getResourceAsStream(cp)) {
+            if (in == null) throw new IOException("classpath resource missing: " + cp);
+            Files.copy(in, dest, StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+}

--- a/ace-copilot-llm/src/test/resources/copilot/mock-sidecar.mjs
+++ b/ace-copilot-llm/src/test/resources/copilot/mock-sidecar.mjs
@@ -1,0 +1,74 @@
+// Test double for ace-copilot-sidecar/sidecar.mjs.
+//
+// Speaks the same LSP-framed JSON-RPC protocol on stdio but does not
+// import @github/copilot-sdk or touch the network. Used by
+// CopilotAcpClientSmokeTest to exercise the Java client end-to-end.
+//
+// Behavior:
+//   - initialize         -> { protocolVersion: "0.1" }
+//   - session.sendAndWait -> emits 2 session/text deltas and 2 session/usage
+//                           events (initiator=user with premiumUsed=N,
+//                           then initiator=agent with premiumUsed=N+1),
+//                           then replies with the canned assistant content.
+//   - shutdown           -> responds null and exits.
+
+function writeMessage(obj) {
+  const body = JSON.stringify(obj);
+  const buf = Buffer.from(body, "utf8");
+  process.stdout.write(`Content-Length: ${buf.length}\r\n\r\n`);
+  process.stdout.write(buf);
+}
+
+let buffer = Buffer.alloc(0);
+process.stdin.on("data", (chunk) => {
+  buffer = Buffer.concat([buffer, chunk]);
+  while (true) {
+    const sep = buffer.indexOf("\r\n\r\n");
+    if (sep < 0) return;
+    const m = /Content-Length:\s*(\d+)/i.exec(buffer.slice(0, sep).toString("utf8"));
+    if (!m) { process.exit(2); }
+    const len = parseInt(m[1], 10);
+    const bodyStart = sep + 4;
+    if (buffer.length < bodyStart + len) return;
+    const body = buffer.slice(bodyStart, bodyStart + len).toString("utf8");
+    buffer = buffer.slice(bodyStart + len);
+    handle(JSON.parse(body));
+  }
+});
+
+function handle(msg) {
+  const { id, method } = msg;
+  switch (method) {
+    case "initialize": {
+      writeMessage({ jsonrpc: "2.0", id, result: { protocolVersion: "0.1" } });
+      return;
+    }
+    case "session.sendAndWait": {
+      writeMessage({ jsonrpc: "2.0", method: "session/text", params: { delta: "Hello " } });
+      writeMessage({
+        jsonrpc: "2.0", method: "session/usage",
+        params: { model: "test-model", initiator: "user", premiumUsed: 42, premiumLimit: 100 },
+      });
+      writeMessage({ jsonrpc: "2.0", method: "session/text", params: { delta: "world." } });
+      writeMessage({
+        jsonrpc: "2.0", method: "session/usage",
+        params: { model: "test-model", initiator: "agent", premiumUsed: 43, premiumLimit: 100 },
+      });
+      writeMessage({
+        jsonrpc: "2.0", id,
+        result: { content: "Hello world.", stopReason: "COMPLETE" },
+      });
+      return;
+    }
+    case "shutdown": {
+      writeMessage({ jsonrpc: "2.0", id, result: null });
+      process.exit(0);
+    }
+    default: {
+      writeMessage({
+        jsonrpc: "2.0", id,
+        error: { code: -32601, message: "unknown method: " + method },
+      });
+    }
+  }
+}

--- a/ace-copilot-sidecar/.gitignore
+++ b/ace-copilot-sidecar/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/ace-copilot-sidecar/package-lock.json
+++ b/ace-copilot-sidecar/package-lock.json
@@ -1,0 +1,160 @@
+{
+  "name": "ace-copilot-sidecar",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ace-copilot-sidecar",
+      "version": "0.0.1",
+      "dependencies": {
+        "@github/copilot-sdk": "^0.2.2"
+      }
+    },
+    "node_modules/@github/copilot": {
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.32.tgz",
+      "integrity": "sha512-ydEYAztJQa1sLQw+WPmnkkt3Sf/k2Smn/7szzYvt1feUOdNIak1gHpQhKcgPr2w252gjVLRWjOiynoeLVW0Fbw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "bin": {
+        "copilot": "npm-loader.js"
+      },
+      "optionalDependencies": {
+        "@github/copilot-darwin-arm64": "1.0.32",
+        "@github/copilot-darwin-x64": "1.0.32",
+        "@github/copilot-linux-arm64": "1.0.32",
+        "@github/copilot-linux-x64": "1.0.32",
+        "@github/copilot-win32-arm64": "1.0.32",
+        "@github/copilot-win32-x64": "1.0.32"
+      }
+    },
+    "node_modules/@github/copilot-darwin-arm64": {
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.32.tgz",
+      "integrity": "sha512-RtGHpnrbP1eVtpzitLqC0jkBlo63PJiByv6W/NTtLw4ZAllumb5kMk8JaTtydKl9DCOHA0wfXbG5/JkGXuQ81g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-darwin-x64": {
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.32.tgz",
+      "integrity": "sha512-eyF6uy8gcZ4m/0UdM9UoykMDotZ8hZPJ1xIg0iHy4wrNtkYOaAspAoVpOkm50ODOQAHJ5PVV+9LuT6IoeL+wHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-arm64": {
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.32.tgz",
+      "integrity": "sha512-acRAu5ehFPnw3hQSIxcmi7wzv8PAYd+nqdxZXizOi++en3QWgez7VEXiKLe9Ukf50iiGReg19yvWV4iDOGC0HQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-x64": {
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.32.tgz",
+      "integrity": "sha512-lw86YDwkTKwmeVpfnPErDe9DhemrOHN+l92xOU9wQSH5/d+HguXwRb3e4cQjlxsGLS+/fWRGtwf+u2fbQ37avw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-sdk": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-0.2.2.tgz",
+      "integrity": "sha512-VZCqS08YlUM90bUKJ7VLeIxgTTEHtfXBo84T1IUMNvXRREX2csjPH6Z+CPw3S2468RcCLvzBXcc9LtJJTLIWFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@github/copilot": "^1.0.21",
+        "vscode-jsonrpc": "^8.2.1",
+        "zod": "^4.3.6"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@github/copilot-win32-arm64": {
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.32.tgz",
+      "integrity": "sha512-+eZpuzgBbLHMIzltH541wfbbMy0HEdG91ISzRae3qPCssf3Ad85sat6k7FWTRBSZBFrN7z4yMQm5gROqDJYGSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-arm64": "copilot.exe"
+      }
+    },
+    "node_modules/@github/copilot-win32-x64": {
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.32.tgz",
+      "integrity": "sha512-R6SW1dsEVmPMhrN/WRTetS4gVxcuYcxi2zfDPOfcjW3W0iD0Vwpt3MlqwBaU2UL36j+rnTnmiOA+g82FIBCYVg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-x64": "copilot.exe"
+      }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
+      "integrity": "sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/ace-copilot-sidecar/package.json
+++ b/ace-copilot-sidecar/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "ace-copilot-sidecar",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "description": "Long-running Node subprocess that bridges the Java ace-copilot daemon to @github/copilot-sdk over LSP-framed JSON-RPC on stdio.",
+  "main": "sidecar.mjs",
+  "scripts": {
+    "start": "node sidecar.mjs"
+  },
+  "dependencies": {
+    "@github/copilot-sdk": "^0.2.2"
+  }
+}

--- a/ace-copilot-sidecar/sidecar.mjs
+++ b/ace-copilot-sidecar/sidecar.mjs
@@ -1,0 +1,173 @@
+// ace-copilot Copilot SDK sidecar.
+//
+// Bridges the Java ace-copilot daemon to @github/copilot-sdk over LSP-framed
+// JSON-RPC on stdio. One sidecar process = one long-lived Copilot session;
+// the daemon spawns one sidecar per ace-copilot session.
+//
+// Wire protocol:
+//   - Framing: LSP-style `Content-Length: N\r\n\r\n<body>` (UTF-8 JSON)
+//   - Requests from daemon:
+//       initialize        { githubToken?: string }      → { protocolVersion }
+//       session.sendAndWait { model, prompt }           → { content, stopReason }
+//       shutdown          null                          → null (then exit 0)
+//   - Notifications from sidecar during session.sendAndWait:
+//       session/text   { delta }
+//       session/usage  { model, inputTokens, outputTokens, cost, initiator,
+//                        premiumUsed, premiumLimit }
+//   - Logs go to stderr, not stdout (stdout carries framed JSON-RPC only).
+
+import { CopilotClient, approveAll } from "@github/copilot-sdk";
+
+const log = (...args) => process.stderr.write(`[sidecar] ${args.join(" ")}\n`);
+
+function writeMessage(obj) {
+  const body = JSON.stringify(obj);
+  const buf = Buffer.from(body, "utf8");
+  process.stdout.write(`Content-Length: ${buf.length}\r\n\r\n`);
+  process.stdout.write(buf);
+}
+
+let buffer = Buffer.alloc(0);
+function onStdinData(chunk) {
+  buffer = Buffer.concat([buffer, chunk]);
+  while (true) {
+    const sep = buffer.indexOf("\r\n\r\n");
+    if (sep < 0) return;
+    const header = buffer.slice(0, sep).toString("utf8");
+    const m = /Content-Length:\s*(\d+)/i.exec(header);
+    if (!m) {
+      log("malformed header:", JSON.stringify(header));
+      process.exit(2);
+    }
+    const len = parseInt(m[1], 10);
+    const bodyStart = sep + 4;
+    if (buffer.length < bodyStart + len) return;
+    const body = buffer.slice(bodyStart, bodyStart + len).toString("utf8");
+    buffer = buffer.slice(bodyStart + len);
+    let msg;
+    try {
+      msg = JSON.parse(body);
+    } catch (e) {
+      log("bad json body:", e.message);
+      continue;
+    }
+    handleMessage(msg).catch((err) => log("handler threw:", err?.stack ?? err));
+  }
+}
+
+process.stdin.on("data", onStdinData);
+process.stdin.on("end", () => process.exit(0));
+
+let client = null;
+let session = null;
+let currentModel = null;
+let githubToken = null;
+
+function attachSessionListeners(s) {
+  s.on((event) => {
+    if (!event?.type) return;
+    if (event.type === "assistant.message_delta" || event.type === "assistant.reasoning_delta") {
+      const delta = event.data?.deltaContent ?? event.data?.delta;
+      if (delta) {
+        writeMessage({ jsonrpc: "2.0", method: "session/text", params: { delta } });
+      }
+    } else if (event.type === "assistant.usage") {
+      const q = event.data?.quotaSnapshots?.premium_interactions;
+      writeMessage({
+        jsonrpc: "2.0",
+        method: "session/usage",
+        params: {
+          model: event.data?.model ?? null,
+          inputTokens: event.data?.inputTokens ?? null,
+          outputTokens: event.data?.outputTokens ?? null,
+          cost: event.data?.cost ?? null,
+          initiator: event.data?.initiator ?? null,
+          premiumUsed: q?.usedRequests ?? null,
+          premiumLimit: q?.entitlementRequests ?? null,
+        },
+      });
+    }
+  });
+}
+
+async function ensureSession(model) {
+  if (!client) {
+    const opts = {};
+    if (githubToken) {
+      opts.githubToken = githubToken;
+      opts.useLoggedInUser = false;
+    }
+    client = new CopilotClient(opts);
+    log("CopilotClient created", githubToken ? "(with supplied token)" : "(using logged-in user)");
+  }
+  if (!session || currentModel !== model) {
+    if (session) {
+      try {
+        await session.disconnect();
+      } catch (e) {
+        log("session.disconnect failed:", e.message);
+      }
+    }
+    session = await client.createSession({
+      model,
+      streaming: true,
+      onPermissionRequest: approveAll,
+    });
+    currentModel = model;
+    attachSessionListeners(session);
+    log(`session created model=${model}`);
+  }
+  return session;
+}
+
+async function handleMessage(msg) {
+  const { id, method, params } = msg;
+  try {
+    let result;
+    switch (method) {
+      case "initialize": {
+        githubToken = params?.githubToken ?? null;
+        result = { protocolVersion: "0.1" };
+        break;
+      }
+      case "session.sendAndWait": {
+        const model = params?.model;
+        const prompt = params?.prompt;
+        if (!model) throw new Error("'model' is required");
+        if (!prompt) throw new Error("'prompt' is required");
+        const s = await ensureSession(model);
+        const r = await s.sendAndWait({ prompt });
+        result = {
+          content: r?.data?.content ?? null,
+          stopReason: r?.data?.stopReason ?? null,
+        };
+        break;
+      }
+      case "shutdown": {
+        if (session) {
+          try { await session.disconnect(); } catch {}
+        }
+        if (client) {
+          try { await client.stop(); } catch {}
+        }
+        if (id !== undefined) writeMessage({ jsonrpc: "2.0", id, result: null });
+        process.exit(0);
+        return;
+      }
+      default:
+        throw new Error(`unknown method: ${method}`);
+    }
+    if (id !== undefined) writeMessage({ jsonrpc: "2.0", id, result });
+  } catch (e) {
+    log("error handling", method, ":", e?.message ?? e);
+    if (id !== undefined) {
+      writeMessage({
+        jsonrpc: "2.0",
+        id,
+        error: { code: -32000, message: String(e?.message ?? e) },
+      });
+    }
+  }
+}
+
+log("ready");

--- a/experiments/copilot-session-probe/.gitignore
+++ b/experiments/copilot-session-probe/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/experiments/copilot-session-probe/package-lock.json
+++ b/experiments/copilot-session-probe/package-lock.json
@@ -1,0 +1,160 @@
+{
+  "name": "copilot-session-probe",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "copilot-session-probe",
+      "version": "0.0.1",
+      "dependencies": {
+        "@github/copilot-sdk": "^0.2.2"
+      }
+    },
+    "node_modules/@github/copilot": {
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.32.tgz",
+      "integrity": "sha512-ydEYAztJQa1sLQw+WPmnkkt3Sf/k2Smn/7szzYvt1feUOdNIak1gHpQhKcgPr2w252gjVLRWjOiynoeLVW0Fbw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "bin": {
+        "copilot": "npm-loader.js"
+      },
+      "optionalDependencies": {
+        "@github/copilot-darwin-arm64": "1.0.32",
+        "@github/copilot-darwin-x64": "1.0.32",
+        "@github/copilot-linux-arm64": "1.0.32",
+        "@github/copilot-linux-x64": "1.0.32",
+        "@github/copilot-win32-arm64": "1.0.32",
+        "@github/copilot-win32-x64": "1.0.32"
+      }
+    },
+    "node_modules/@github/copilot-darwin-arm64": {
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.32.tgz",
+      "integrity": "sha512-RtGHpnrbP1eVtpzitLqC0jkBlo63PJiByv6W/NTtLw4ZAllumb5kMk8JaTtydKl9DCOHA0wfXbG5/JkGXuQ81g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-darwin-x64": {
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.32.tgz",
+      "integrity": "sha512-eyF6uy8gcZ4m/0UdM9UoykMDotZ8hZPJ1xIg0iHy4wrNtkYOaAspAoVpOkm50ODOQAHJ5PVV+9LuT6IoeL+wHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-arm64": {
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.32.tgz",
+      "integrity": "sha512-acRAu5ehFPnw3hQSIxcmi7wzv8PAYd+nqdxZXizOi++en3QWgez7VEXiKLe9Ukf50iiGReg19yvWV4iDOGC0HQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-x64": {
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.32.tgz",
+      "integrity": "sha512-lw86YDwkTKwmeVpfnPErDe9DhemrOHN+l92xOU9wQSH5/d+HguXwRb3e4cQjlxsGLS+/fWRGtwf+u2fbQ37avw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-sdk": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-0.2.2.tgz",
+      "integrity": "sha512-VZCqS08YlUM90bUKJ7VLeIxgTTEHtfXBo84T1IUMNvXRREX2csjPH6Z+CPw3S2468RcCLvzBXcc9LtJJTLIWFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@github/copilot": "^1.0.21",
+        "vscode-jsonrpc": "^8.2.1",
+        "zod": "^4.3.6"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@github/copilot-win32-arm64": {
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.32.tgz",
+      "integrity": "sha512-+eZpuzgBbLHMIzltH541wfbbMy0HEdG91ISzRae3qPCssf3Ad85sat6k7FWTRBSZBFrN7z4yMQm5gROqDJYGSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-arm64": "copilot.exe"
+      }
+    },
+    "node_modules/@github/copilot-win32-x64": {
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.32.tgz",
+      "integrity": "sha512-R6SW1dsEVmPMhrN/WRTetS4gVxcuYcxi2zfDPOfcjW3W0iD0Vwpt3MlqwBaU2UL36j+rnTnmiOA+g82FIBCYVg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-x64": "copilot.exe"
+      }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
+      "integrity": "sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/experiments/copilot-session-probe/package.json
+++ b/experiments/copilot-session-probe/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "copilot-session-probe",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "description": "Track A probe for ace-copilot issue #1 — verify Copilot SDK session-internal clarification mechanism",
+  "scripts": {
+    "probe": "node probe.mjs",
+    "probe:usage": "node probe-usage.mjs",
+    "smoke": "node uds-smoke.mjs"
+  },
+  "dependencies": {
+    "@github/copilot-sdk": "^0.2.2"
+  }
+}

--- a/experiments/copilot-session-probe/probe-usage.mjs
+++ b/experiments/copilot-session-probe/probe-usage.mjs
@@ -1,0 +1,99 @@
+// Track B preliminary probe: dump full SDK event payloads to look for any
+// billing / usage / premium-request metadata that might be surfaced to the
+// client. If nothing appears, billing verification must be done via the
+// user's GitHub settings dashboard (no per-user usage API exists).
+//
+// Run: GH_ACCOUNT=xinhua-gu_acncp MODEL=claude-haiku-4.5 node probe-usage.mjs
+
+import { CopilotClient, approveAll } from "@github/copilot-sdk";
+import { execFileSync } from "node:child_process";
+
+const MODEL = process.env.MODEL ?? "gpt-4.1";
+const GH_ACCOUNT = process.env.GH_ACCOUNT ?? null;
+
+function resolveAccountToken(account) {
+  return execFileSync("gh", ["auth", "token", "--user", account], {
+    encoding: "utf8", stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+const AMBIGUOUS_PROMPT = `
+I need a tiny utility. Ask me exactly TWO clarifying questions using ask_user,
+wait for each answer, then STOP without writing any code. Just summarize.
+`.trim();
+const ANSWERS = ["Echo stdin to stdout.", "Node.js."];
+
+function sanitize(obj, depth = 0) {
+  if (depth > 3 || obj == null) return obj;
+  if (typeof obj === "string") return obj.length > 120 ? obj.slice(0, 120) + "…" : obj;
+  if (Array.isArray(obj)) return obj.slice(0, 3).map((v) => sanitize(v, depth + 1));
+  if (typeof obj === "object") {
+    const out = {};
+    for (const [k, v] of Object.entries(obj)) out[k] = sanitize(v, depth + 1);
+    return out;
+  }
+  return obj;
+}
+
+async function main() {
+  const opts = {};
+  if (GH_ACCOUNT) { opts.githubToken = resolveAccountToken(GH_ACCOUNT); opts.useLoggedInUser = false; }
+  const client = new CopilotClient(opts);
+
+  let uiCount = 0;
+  const session = await client.createSession({
+    model: MODEL,
+    streaming: true,
+    onPermissionRequest: approveAll,
+    onUserInputRequest: async (req) => {
+      uiCount++;
+      return { answer: ANSWERS[uiCount - 1] ?? "proceed", wasFreeform: true };
+    },
+  });
+
+  // Log EVERY assistant.usage event — this carries quotaSnapshots.premium_interactions.usedRequests,
+  // the real counter we need to verify per-session vs per-turn billing.
+  const usages = [];
+  session.on((event) => {
+    if (event?.type === "assistant.usage") {
+      const q = event.data?.quotaSnapshots?.premium_interactions;
+      const snap = {
+        t: new Date().toISOString(),
+        apiCallId: event.data?.apiCallId,
+        initiator: event.data?.initiator,
+        inputTokens: event.data?.inputTokens,
+        outputTokens: event.data?.outputTokens,
+        cost: event.data?.cost,
+        premiumUsed: q?.usedRequests,
+        premiumRemainingPct: q?.remainingPercentage,
+      };
+      usages.push(snap);
+      console.log(`[usage#${usages.length}] premium_used=${snap.premiumUsed}  initiator=${snap.initiator}  apiCall=${snap.apiCallId?.slice(0,8)}  cost=${snap.cost}`);
+    }
+  });
+
+  console.log(`[probe] sending prompt (GH_ACCOUNT=${GH_ACCOUNT ?? "default"}, MODEL=${MODEL})`);
+  const result = await session.sendAndWait({ prompt: AMBIGUOUS_PROMPT });
+
+  console.log("\n[probe] ---------- BILLING VERDICT ----------");
+  console.log(`  user_input.requested fired:      ${uiCount}`);
+  console.log(`  assistant.usage events fired:    ${usages.length}`);
+  if (usages.length > 0) {
+    const first = usages[0].premiumUsed;
+    const last = usages[usages.length - 1].premiumUsed;
+    const delta = last - first;
+    console.log(`  premium_interactions.usedRequests:`);
+    console.log(`    before first turn (reported): ${first}`);
+    console.log(`    after last turn  (reported):  ${last}`);
+    console.log(`    delta across session:         ${delta}`);
+    console.log("  initiators per usage event:");
+    usages.forEach((u, i) => console.log(`    #${i + 1} initiator=${u.initiator}  premium_used=${u.premiumUsed}`));
+    console.log(`\n  Interpretation:`);
+    console.log(`    If delta == 1 despite ${uiCount} user_input round-trips → session counts as 1 request.`);
+    console.log(`    If delta == ${uiCount + 1} or matches assistant.usage count → each LLM turn is a request.`);
+  }
+
+  await client.stop();
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/experiments/copilot-session-probe/probe.mjs
+++ b/experiments/copilot-session-probe/probe.mjs
@@ -1,0 +1,143 @@
+// Track A probe for ace-copilot issue #1.
+//
+// Verifies that a standalone Node process can:
+//   1. Start a Copilot session via @github/copilot-sdk
+//   2. Receive user_input.requested events from inside that session
+//   3. Respond programmatically and have the session continue
+//      without issuing a new external prompt
+//
+// This is a pure feasibility check — no billing measurement here.
+// Billing comparison belongs to Track B.
+//
+// Run:
+//   cd experiments/copilot-session-probe
+//   npm install
+//   node probe.mjs                                      # uses gh active account
+//   MODEL=gpt-4.1 node probe.mjs                        # override model
+//   GH_ACCOUNT=xinhua-gu_acncp node probe.mjs           # use a specific gh account
+//                                                         without touching `gh auth switch`
+//
+// Auth:
+//   - If GH_ACCOUNT is set, resolves token via `gh auth token --user <acct>`
+//     and passes it to the SDK explicitly (useLoggedInUser:false). This mirrors
+//     ace-copilot's CopilotTokenProvider token resolution, scoped to a chosen
+//     gh-stored account — does NOT alter the global active account.
+//   - Otherwise, the SDK discovers credentials on its own.
+
+import { CopilotClient, approveAll } from "@github/copilot-sdk";
+import { execFileSync } from "node:child_process";
+
+const MODEL = process.env.MODEL ?? "gpt-5";
+const GH_ACCOUNT = process.env.GH_ACCOUNT ?? null;
+
+function resolveAccountToken(account) {
+  const out = execFileSync("gh", ["auth", "token", "--user", account], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const token = out.trim();
+  if (!token) throw new Error(`gh auth token --user ${account} returned empty`);
+  return token;
+}
+
+const AMBIGUOUS_PROMPT = `
+I want a small utility, but I have not decided the details.
+
+BEFORE writing any code, you MUST ask me at least TWO separate clarifying
+questions using the ask_user tool. Each question must wait for my answer
+before the next one. Do not guess. Do not write code until I have answered.
+
+Start by asking your first clarifying question now.
+`.trim();
+
+const CANNED_ANSWERS = [
+  "A CLI that counts word frequencies in stdin.",
+  "Node.js, ESM, no dependencies.",
+  "Read from stdin; print a JSON object {word: count} to stdout; sort by count desc.",
+];
+
+async function main() {
+  const started = Date.now();
+  const clientOpts = {};
+  if (GH_ACCOUNT) {
+    clientOpts.githubToken = resolveAccountToken(GH_ACCOUNT);
+    clientOpts.useLoggedInUser = false;
+    console.log(`[probe] using gh account: ${GH_ACCOUNT} (token resolved, gh active account unchanged)`);
+  }
+  const client = new CopilotClient(clientOpts);
+  console.log(`[probe] client created (model=${MODEL})`);
+
+  let userInputCount = 0;
+  const timeline = [];
+
+  const session = await client.createSession({
+    model: MODEL,
+    streaming: true,
+    onPermissionRequest: approveAll,
+    onUserInputRequest: async (req) => {
+      userInputCount++;
+      const answer =
+        CANNED_ANSWERS[userInputCount - 1] ?? "No further details, please proceed.";
+
+      console.log(`\n[probe] >>> user_input.requested #${userInputCount}`);
+      console.log(`        question:      ${req.question}`);
+      if (req.choices?.length) {
+        console.log(`        choices:       ${req.choices.join(" | ")}`);
+      }
+      console.log(`        allowFreeform: ${req.allowFreeform ?? true}`);
+      console.log(`[probe] <<< answering in-session: ${JSON.stringify(answer)}`);
+
+      timeline.push({
+        t: Date.now() - started,
+        event: "user_input.requested",
+        question: req.question,
+      });
+      return { answer, wasFreeform: true };
+    },
+  });
+  console.log("[probe] session created");
+
+  session.on("assistant.message_delta", (e) => {
+    const chunk = e.data?.deltaContent ?? e.data?.delta ?? "";
+    if (chunk) process.stdout.write(chunk);
+  });
+  session.on("assistant.message", () => {
+    timeline.push({ t: Date.now() - started, event: "assistant.message" });
+  });
+  session.on("session.idle", () => {
+    timeline.push({ t: Date.now() - started, event: "session.idle" });
+  });
+
+  console.log("\n[probe] sending ambiguous prompt, expecting mid-session clarifications...\n");
+  await session.sendAndWait({ prompt: AMBIGUOUS_PROMPT });
+
+  console.log("\n\n[probe] ---------- SUMMARY ----------");
+  console.log(`  model:                       ${MODEL}`);
+  console.log(`  user_input.requested fired:  ${userInputCount} time(s)`);
+  console.log(`  timeline entries:            ${timeline.length}`);
+  console.log("  timeline:");
+  for (const e of timeline) {
+    const extra = e.question ? ` :: ${e.question.slice(0, 60)}` : "";
+    console.log(`    +${String(e.t).padStart(6)}ms  ${e.event}${extra}`);
+  }
+
+  const pass = userInputCount >= 1;
+  console.log(`\n  TRACK A VERDICT:             ${pass ? "PASS" : "FAIL"}`);
+  if (pass) {
+    console.log("  -> Copilot SDK session-internal clarification is reachable from a Node process.");
+    console.log("     Same session continued after in-handler answer (no new sendAndWait issued).");
+    console.log("     Next: Track B billing comparison with N runs over the dashboard delta.");
+  } else {
+    console.log("  -> Agent never invoked ask_user. Mechanism unverified from this probe.");
+    console.log("     Try a different model, a more constraining prompt, or inspect whether");
+    console.log("     the SDK surfaces the event through a different channel.");
+  }
+
+  await client.stop();
+  process.exit(pass ? 0 : 2);
+}
+
+main().catch((err) => {
+  console.error("\n[probe] error:", err?.stack ?? err);
+  process.exit(1);
+});

--- a/experiments/copilot-session-probe/uds-smoke.mjs
+++ b/experiments/copilot-session-probe/uds-smoke.mjs
@@ -1,0 +1,86 @@
+// One-shot JSON-RPC smoke client for the ace-copilot daemon UDS socket.
+// Creates a session, sends agent.prompt, prints stream.text + usage.copilot.
+// Used to verify Phase 1 (issue #3): copilotRuntime=session routes through
+// the sidecar and reports premiumDelta.
+
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+
+const SOCK = path.join(os.homedir(), ".ace-copilot", "ace-copilot.sock");
+const WORKSPACE = process.argv[2] ?? process.cwd();
+const PROMPT = process.argv[3] ?? "List the files in this directory and describe the project in one sentence. Use tools.";
+
+const client = net.createConnection(SOCK);
+let buf = "";
+let nextId = 1;
+const pending = new Map();
+
+function send(msg) {
+  client.write(JSON.stringify(msg) + "\n");
+}
+function request(method, params) {
+  return new Promise((resolve, reject) => {
+    const id = nextId++;
+    pending.set(id, { resolve, reject });
+    send({ jsonrpc: "2.0", id, method, params });
+  });
+}
+
+client.on("data", (chunk) => {
+  buf += chunk.toString("utf8");
+  let nl;
+  while ((nl = buf.indexOf("\n")) >= 0) {
+    const line = buf.slice(0, nl);
+    buf = buf.slice(nl + 1);
+    if (!line) continue;
+    let msg;
+    try { msg = JSON.parse(line); } catch { continue; }
+    if (msg.method) {
+      if (msg.method === "stream.text") {
+        process.stdout.write(msg.params?.delta ?? "");
+      } else if (msg.method === "stream.tool_use") {
+        process.stderr.write(`\n[tool_use] ${msg.params?.name}(${msg.params?.summary ?? ""})\n`);
+      } else if (msg.method === "stream.thinking") {
+        // drop
+      } else {
+        process.stderr.write(`\n[notif] ${msg.method}\n`);
+      }
+    } else if (msg.id !== undefined) {
+      const p = pending.get(msg.id);
+      if (p) {
+        pending.delete(msg.id);
+        if (msg.error) p.reject(new Error(msg.error.message ?? JSON.stringify(msg.error)));
+        else p.resolve(msg.result);
+      }
+    }
+  }
+});
+
+client.on("error", (e) => { console.error("[sock]", e.message); process.exit(1); });
+client.on("close", () => {});
+
+async function main() {
+  const health = await request("health.status", {});
+  console.error("[health] model=" + health?.model);
+
+  const session = await request("session.create", { project: WORKSPACE });
+  const sessionId = session?.sessionId ?? session?.id;
+  console.error("[session] id=" + sessionId);
+
+  console.error("[prompt]", PROMPT);
+  console.error("----");
+  const start = Date.now();
+  const result = await request("agent.prompt", { sessionId, prompt: PROMPT });
+  const ms = Date.now() - start;
+  console.error("\n----");
+  console.error(`[result] stopReason=${result?.stopReason} wallMs=${ms}`);
+  if (result?.usage) {
+    console.error("[usage] " + JSON.stringify(result.usage, null, 2));
+  }
+
+  await request("session.destroy", { sessionId }).catch(() => {});
+  client.end();
+}
+
+main().catch((e) => { console.error("[error]", e.message); process.exit(1); });

--- a/install.sh
+++ b/install.sh
@@ -11,6 +11,8 @@
 #   4. Creates ace-copilot, ace-copilot-tui, ace-copilot-restart, ace-copilot-update commands
 #
 # No build tools required — only Java 21 runtime.
+# Optional: Node.js 20+ on PATH if you opt into copilotRuntime="session" (issue #3)
+# for GitHub Copilot. The default copilotRuntime="chat" does not need Node.
 # Supports: macOS, Linux, Windows (Git Bash / WSL)
 set -e
 


### PR DESCRIPTION
## Summary

- Route user prompts on the Copilot provider through one `@github/copilot-sdk` `session.sendAndWait` per prompt, via a Node sidecar — internal ReAct depth, tool use, and clarification round-trips all cost **0** extra `premium_interactions.usedRequests`.
- Gated by `copilotRuntime = "session"` on the active profile; default stays `"chat"` so existing installs are unaffected.
- Adds `CopilotSessionEvent` / `CopilotSessionResponse` sealed interfaces mirroring the SDK's `user_input.requested` / `elicitation.requested` (groundwork for Phase 3, #5).

Phase 1 scope only — SDK uses its own built-in tools and permission model. Phase 2 (#4) exposes ace-copilot's 6 tools via `defineTool` and wires `PermissionManager`. Phase 3 (#5) adds `respondToUserInput` routing. Phase 4 (#6) audits planner / self-improvement consolidation.

## Evidence

Tool-exercising prompt on `claude-haiku-4.5` through the full daemon path (one UDS `agent.prompt`):

```
[result] stopReason=COMPLETE wallMs=12361
[usage.copilot] premiumUsedBefore=213, premiumUsedAfter=214, premiumDelta=1,
                usageEvents=2, initiatorFirst=user, initiatorLast=agent
```

Same prompt on the existing `/chat/completions` path would issue ≥2 billable LLM calls (one to decide the tool, one to synthesize after the tool result).

## What changed

- `ace-copilot-sidecar/` — new Node project wrapping `@github/copilot-sdk`, speaks LSP-framed JSON-RPC on stdio
- `ace-copilot-llm/.../copilot/CopilotAcpClient.java` — Java bridge that launches/speaks to the sidecar and surfaces `premium_interactions.usedRequests`
- `ace-copilot-llm/.../copilot/CopilotAcpClientMain.java` — standalone verification entrypoint (`./gradlew :ace-copilot-llm:runCopilotAcpMain`)
- `ace-copilot-llm/.../copilot/session/CopilotSessionEvent.java` + `CopilotSessionResponse.java` — sealed interfaces matching the SDK's documented event payloads
- `AceCopilotConfig.java` — new `copilotRuntime` string field (default `"chat"`; accepts `"chat"` or `"session"`)
- `StreamingAgentHandler.java` — dispatch branch in `handlePrompt`; new `handlePromptViaCopilotSession` that streams text via existing `stream.text` notifications and reports premium delta on `result.usage.copilot`; sidecar lifecycle hooked into `clearSessionMetrics`
- `AceCopilotDaemon.java` — wires `setCopilotRuntimeConfig` + `resolveCopilotSidecarDir` (honors `ACE_COPILOT_SIDECAR_DIR`)
- `experiments/copilot-session-probe/` — Track A/B probes from #1 plus a new `uds-smoke.mjs` one-shot daemon smoke client

## Known Phase 1 limitations (documented in code, deferred by design)

- SDK agent uses its built-in filesystem / shell tools, not ace-copilot's 6 — auto-approved via sidecar `approveAll`, so file-write side effects bypass `PermissionManager` (Phase 2, #4)
- Follow-up user messages are new `sendAndWait` calls, not `respondToUserInput` round-trips — each still costs 1 premium (Phase 3, #5)
- No planner / self-improvement / checkpoint / compaction integration on this path (Phase 4, #6)
- Cancellation is best-effort: `sendAndWait` runs to completion; no wire-level interrupt

## Test plan

- [x] Full project build passes (`./gradlew build -x test`)
- [x] `./gradlew :ace-copilot-llm:runCopilotAcpMain` end-to-end (sidecar + Java client, bypasses daemon)
- [x] `daemon start` + UDS smoke client with `copilotRuntime=session` on `copilot-haiku` profile — observed `premiumDelta=1` for a multi-step prompt
- [x] Flag off (`copilotRuntime=chat`, default) — existing `/chat/completions` path unchanged
- [ ] Reviewer: flip flag back to `chat` after testing to confirm no state leaks between sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)