### PR TITLE
review: cross-turn premium delta samples last, not first

### DIFF
--- a/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/StreamingAgentHandler.java
+++ b/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/StreamingAgentHandler.java
@@ -1829,6 +1829,42 @@ public final class StreamingAgentHandler {
     }
 
     /**
+     * Honest cross-turn premium delta: diff THIS turn's LAST usage sample
+     * against the PREVIOUS turn's last sample (both end-of-turn values).
+     *
+     * <p>Sampling at the current turn's {@code firstUsage} races with the
+     * backend's eventually-consistent counter: if the +1 lands after the
+     * first {@code assistant.usage} fires but before the last, a billable
+     * turn under (first - prevLast) would report 0. {@code last} always
+     * gives the SDK maximum time to flush, so {@code last - prevLast} is
+     * monotonically non-decreasing and captures the increment regardless
+     * of when inside the turn it landed.
+     *
+     * <p>Returns -1 when no baseline exists (first turn of a session) or
+     * {@code last.premiumUsed} is missing.
+     */
+    static long computeCrossTurnPremiumDelta(Long previousSessionPremium,
+                                             CopilotAcpClient.UsageSnapshot last) {
+        if (previousSessionPremium == null) return -1;
+        if (last == null || last.premiumUsed() == null) return -1;
+        return last.premiumUsed() - previousSessionPremium;
+    }
+
+    /**
+     * Picks the premium-counter value to store as the next turn's baseline.
+     * Prefer the last sample; fall back to the first so a mock or SDK that
+     * only emits one {@code assistant.usage} event still leaves a baseline
+     * behind. Returns {@code null} when neither is available — in that case
+     * the next turn will simply report {@code -1} (no baseline).
+     */
+    static Long resolvePremiumBaseline(CopilotAcpClient.UsageSnapshot last,
+                                       CopilotAcpClient.UsageSnapshot first) {
+        if (last != null && last.premiumUsed() != null) return last.premiumUsed();
+        if (first != null && first.premiumUsed() != null) return first.premiumUsed();
+        return null;
+    }
+
+    /**
      * Deterministic signature of a tool descriptor list. Must match the
      * sidecar's {@code toolSignature()} (see {@code sidecar.mjs}) so the
      * Java-side pre-warn agrees with the sidecar's post-hoc
@@ -2081,22 +2117,11 @@ public final class StreamingAgentHandler {
         // as `llmRequests` (which the CLI renders as the billing indicator).
         usageNode.put("llmRequests", 1);
 
-        // Cross-turn premium delta: diff the earliest premium sample of
-        // THIS turn against the last sample we saw on the PREVIOUS turn,
-        // per-session. Intra-turn subtraction is unreliable because the
-        // SDK's first assistant.usage event is not guaranteed to be a
-        // pre-billing baseline (see SendResult.intraTurnPremiumDelta
-        // javadoc). Cross-turn is the honest number.
         Long previousSessionPremium = sessionLastPremiumUsed.get(sessionId);
-        long crossTurnPremiumDelta = -1;
-        if (previousSessionPremium != null
-                && first != null && first.premiumUsed() != null) {
-            crossTurnPremiumDelta = first.premiumUsed() - previousSessionPremium;
-        }
-        if (last != null && last.premiumUsed() != null) {
-            sessionLastPremiumUsed.put(sessionId, last.premiumUsed());
-        } else if (first != null && first.premiumUsed() != null) {
-            sessionLastPremiumUsed.put(sessionId, first.premiumUsed());
+        long crossTurnPremiumDelta = computeCrossTurnPremiumDelta(previousSessionPremium, last);
+        Long updatedBaseline = resolvePremiumBaseline(last, first);
+        if (updatedBaseline != null) {
+            sessionLastPremiumUsed.put(sessionId, updatedBaseline);
         }
 
         // Diagnostics: expose the per-session premium counter so the TUI /

--- a/ace-copilot-daemon/src/test/java/dev/acecopilot/daemon/CopilotCrossTurnPremiumDeltaTest.java
+++ b/ace-copilot-daemon/src/test/java/dev/acecopilot/daemon/CopilotCrossTurnPremiumDeltaTest.java
@@ -1,0 +1,86 @@
+package dev.acecopilot.daemon;
+
+import dev.acecopilot.llm.copilot.CopilotAcpClient;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit coverage for the session-runtime cross-turn premium delta math
+ * (PR #9 review thread).
+ *
+ * <p>GitHub's {@code premium_interactions.usedRequests} counter is
+ * eventually consistent: the +1 for a billable turn can land between two
+ * {@code assistant.usage} events INSIDE the current {@code sendAndWait}.
+ * Sampling at the first event races with the flush; sampling at the last
+ * event does not (it sees whatever the backend has settled on by the time
+ * the turn wraps up). These tests pin that invariant.
+ */
+class CopilotCrossTurnPremiumDeltaTest {
+
+    private static CopilotAcpClient.UsageSnapshot snap(long premiumUsed) {
+        return new CopilotAcpClient.UsageSnapshot(
+                "test-model", 0L, 0L, 0.0, "agent", premiumUsed, 100L);
+    }
+
+    @Test
+    void nullBaselineReturnsMinusOne() {
+        assertThat(StreamingAgentHandler.computeCrossTurnPremiumDelta(null, snap(5)))
+                .as("no previous turn on record -> no comparison possible")
+                .isEqualTo(-1);
+    }
+
+    @Test
+    void missingLastSampleReturnsMinusOne() {
+        assertThat(StreamingAgentHandler.computeCrossTurnPremiumDelta(5L, null))
+                .isEqualTo(-1);
+    }
+
+    @Test
+    void noBillingBetweenTurnsReportsZero() {
+        // Turn N ended at 10, turn N+1 also ended at 10 → no billable
+        // increment landed in either window. Honest 0.
+        assertThat(StreamingAgentHandler.computeCrossTurnPremiumDelta(10L, snap(10)))
+                .isEqualTo(0);
+    }
+
+    @Test
+    void billingBetweenTurnsCapturedCleanly() {
+        // Previous turn settled at 10; this turn's backend has since flushed
+        // to 11 by the last assistant.usage event.
+        assertThat(StreamingAgentHandler.computeCrossTurnPremiumDelta(10L, snap(11)))
+                .isEqualTo(1);
+    }
+
+    @Test
+    void midStreamFlushCapturedByLastNotFirst() {
+        // Race scenario (reviewer's fix): the previous turn ended at 10.
+        // The current turn's first assistant.usage came in BEFORE the
+        // backend incremented — firstUsage.premiumUsed == 10, so an
+        // implementation that subtracts first from prevLast reports 0.
+        // By the last assistant.usage the counter has flushed to 11.
+        // The helper samples last and correctly reports 1.
+        var last = snap(11);
+        assertThat(StreamingAgentHandler.computeCrossTurnPremiumDelta(10L, last))
+                .as("last.premiumUsed must drive the delta, not first.premiumUsed")
+                .isEqualTo(1);
+    }
+
+    @Test
+    void resolveBaselinePrefersLast() {
+        assertThat(StreamingAgentHandler.resolvePremiumBaseline(snap(11), snap(10)))
+                .isEqualTo(11);
+    }
+
+    @Test
+    void resolveBaselineFallsBackToFirst() {
+        assertThat(StreamingAgentHandler.resolvePremiumBaseline(null, snap(10)))
+                .as("when sidecar emits only one usage event the handler stored it as 'first'")
+                .isEqualTo(10);
+    }
+
+    @Test
+    void resolveBaselineReturnsNullWhenBothMissing() {
+        assertThat(StreamingAgentHandler.resolvePremiumBaseline(null, null)).isNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Follow-up review finding on merged PR #9: \`premiumDeltaSinceLastTurn\` was \`(thisTurn.first - prevTurn.last)\` which still races with the backend flush.
- Sample \`thisTurn.last - prevTurn.last\` instead. Both end-of-turn values, monotonically non-decreasing, captures the +1 regardless of when inside the turn it landed.
- Extract the math as package-private static helpers so the race scenario is unit-testable without a daemon.

## Evidence

Our own test data exposed the bug:

| turn | prevLast | first | last | old sinceLastTurn (first − prevLast) | new (last − prevLast) | billed? |
| --- | --- | --- | --- | --- | --- | --- |
| ping | 219 | 220 | 220 | 1 | 1 | yes |
| CLAUDE.md | 220 | **220** | **221** | **0** ❌ | **1** ✓ | yes |

The \"CLAUDE.md\" row is the mid-stream-flush race — the backend incremented \`premium_interactions.usedRequests\` after the first \`assistant.usage\` event but before the last. Old math missed it; new math catches it.

## Changes

- \`StreamingAgentHandler.computeCrossTurnPremiumDelta\` — new static helper, samples \`last\`
- \`StreamingAgentHandler.resolvePremiumBaseline\` — new static helper, prefers \`last\` and falls back to \`first\` when the sidecar emitted only one usage event
- Dispatch code in \`handlePromptViaCopilotSession\` simplified to two calls
- \`CopilotCrossTurnPremiumDeltaTest\` — unit coverage for the five branches (null baseline, null last, zero delta, happy-path +1, race-scenario +1) plus the baseline-resolver fallback

## Follow-up

Updated #10 (combined \`turnBilled\` signal): with this fix \`sinceLastTurn\` is itself authoritative, so the two-signal OR isn't needed anymore. Proposing to close #10 once this lands.

## Test plan

- [x] \`./gradlew build\` passes locally
- [x] New unit test passes; existing smoke + gate tests still green
- [ ] Reviewer: diff the helper math against the reviewer's stated invariant (last − prevLast)

🤖 Generated with [Claude Code](https://claude.com/claude-code)