### PR TITLE
feat(copilot): harden session runtime edges (#12)

### DIFF
--- a/ace-copilot-cli/src/test/java/dev/acecopilot/cli/BackgroundOutputBufferWarningTest.java
+++ b/ace-copilot-cli/src/test/java/dev/acecopilot/cli/BackgroundOutputBufferWarningTest.java
@@ -1,0 +1,41 @@
+package dev.acecopilot.cli;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Guards the fix from PR #8: {@code stream.warning} emitted while a task
+ * is in {@code /bg} was being dropped because {@code OutputSink.onWarning}
+ * had no buffered variant. Issue #12 asks for regression coverage so the
+ * buffering + replay path stays correct when Phase 3 adds more warning
+ * sites (tool catalog resets, elicitation declines, respondToUserInput
+ * state transitions).
+ */
+class BackgroundOutputBufferWarningTest {
+
+    @Test
+    void warningCountedInBufferSize() {
+        var buffer = new BackgroundOutputBuffer();
+        int before = buffer.size();
+        buffer.onWarning("Copilot session context will reset: tool catalog changed");
+        assertThat(buffer.size())
+                .as("onWarning must create a buffered event (not fall through the default no-op)")
+                .isEqualTo(before + 1);
+    }
+
+    @Test
+    void warningIncludedInExtractedText() {
+        var buffer = new BackgroundOutputBuffer();
+        buffer.onTextDelta("agent reply ");
+        buffer.onWarning("remote context reset");
+        buffer.onTextDelta("continues");
+
+        String text = buffer.extractTextContent();
+        assertThat(text)
+                .as("background completion dumps text + errors + warnings so users catch context-reset signals after-the-fact")
+                .contains("agent reply ")
+                .contains("[warning: remote context reset]")
+                .contains("continues");
+    }
+}

--- a/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/StreamingAgentHandler.java
+++ b/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/StreamingAgentHandler.java
@@ -1891,13 +1891,25 @@ public final class StreamingAgentHandler {
      * {@code NeedsUserApproval} decisions through the existing TUI
      * {@code permission.request} flow attached to the active
      * {@link CancelAwareStreamContext}.
+     *
+     * <p>Emits {@code stream.tool_use} before execution and
+     * {@code stream.tool_completed} after, matching the chat-path event
+     * shape so the TUI renders tool activity identically on both paths
+     * (#12). This is the minimum parity the session runtime needs while
+     * first-class mid-execution output streaming for long-running tools
+     * waits for #5's deeper rework.
      */
-    private JsonNode handleCopilotToolInvoke(JsonNode params, ToolRegistry registry) {
+    private JsonNode handleCopilotToolInvoke(JsonNode params,
+                                             ToolRegistry registry,
+                                             CancelAwareStreamContext cancelContext,
+                                             String sessionId) {
         String name = params.path("name").asText("");
         JsonNode args = params.has("arguments") ? params.get("arguments") : objectMapper.createObjectNode();
+        String toolCallId = "copilot-" + sessionId + "-" + System.nanoTime();
 
         var toolOpt = registry.get(name);
         if (toolOpt.isEmpty()) {
+            emitToolCompleted(cancelContext, toolCallId, name, 0, true, "Unknown tool");
             var err = objectMapper.createObjectNode();
             err.put("isError", true);
             err.put("content", "Unknown tool: " + name);
@@ -1907,23 +1919,59 @@ public final class StreamingAgentHandler {
         try {
             inputJson = objectMapper.writeValueAsString(args);
         } catch (IOException e) {
+            emitToolCompleted(cancelContext, toolCallId, name, 0, true, "Invalid arguments");
             var err = objectMapper.createObjectNode();
             err.put("isError", true);
             err.put("content", "Invalid tool arguments: " + e.getMessage());
             return err;
         }
+        emitToolUse(cancelContext, toolCallId, name, inputJson);
+        long started = System.currentTimeMillis();
         try {
             var result = toolOpt.get().execute(inputJson);
+            long durationMs = System.currentTimeMillis() - started;
+            emitToolCompleted(cancelContext, toolCallId, name, durationMs, result.isError(),
+                    result.isError() ? (result.output() != null ? result.output() : "") : "");
             var node = objectMapper.createObjectNode();
             node.put("isError", result.isError());
             node.put("content", result.output() != null ? result.output() : "");
             return node;
         } catch (Exception e) {
+            long durationMs = System.currentTimeMillis() - started;
             log.warn("tool.invoke {} failed: {}", name, e.getMessage());
+            emitToolCompleted(cancelContext, toolCallId, name, durationMs, true, e.getMessage());
             var err = objectMapper.createObjectNode();
             err.put("isError", true);
             err.put("content", "Tool execution failed: " + e.getMessage());
             return err;
+        }
+    }
+
+    private void emitToolUse(CancelAwareStreamContext ctx, String id, String name, String inputJson) {
+        try {
+            var p = objectMapper.createObjectNode();
+            p.put("id", id);
+            p.put("name", name);
+            String summary = StreamingNotificationHandler.summarizeToolInput(name, inputJson, objectMapper);
+            if (summary != null && !summary.isBlank()) p.put("summary", summary);
+            ctx.sendNotification("stream.tool_use", p);
+        } catch (IOException e) {
+            log.debug("Failed to emit stream.tool_use: {}", e.getMessage());
+        }
+    }
+
+    private void emitToolCompleted(CancelAwareStreamContext ctx, String id, String name,
+                                   long durationMs, boolean isError, String errorText) {
+        try {
+            var p = objectMapper.createObjectNode();
+            p.put("id", id);
+            p.put("name", name);
+            p.put("durationMs", durationMs);
+            p.put("isError", isError);
+            if (isError && errorText != null && !errorText.isBlank()) p.put("error", errorText);
+            ctx.sendNotification("stream.tool_completed", p);
+        } catch (IOException e) {
+            log.debug("Failed to emit stream.tool_completed: {}", e.getMessage());
         }
     }
 
@@ -1941,22 +1989,36 @@ public final class StreamingAgentHandler {
     }
 
     /**
-     * Phase 1 dispatch for the Copilot SDK sessionful runtime (issue #3).
+     * Dispatch for the Copilot SDK sessionful runtime (issues #3 spike,
+     * #4 Phase 2, #12 edge hardening).
      *
-     * <p>Delegates one user prompt to {@link CopilotAcpClient#sendAndWait} on the
-     * per-session sidecar. Streams assistant text to the TUI via {@code stream.text}
-     * notifications. Records the assistant's final message on the session history.
+     * <p>Delegates one user prompt to {@link CopilotAcpClient#sendAndWait}
+     * on the per-session sidecar. Streams assistant text via
+     * {@code stream.text}, tool activity via {@code stream.tool_use} and
+     * {@code stream.tool_completed}, and context-reset / elicitation
+     * warnings via {@code stream.warning}. Records the assistant's final
+     * message on the session history.
      *
-     * <p>Known limitations (deferred to later phases):
+     * <p>Tools are resolved from {@code permissionAwareRegistry} so that
+     * {@link dev.acecopilot.security.PermissionAwareTool} — and through it
+     * {@link PermissionManager} — remains the authority for every tool
+     * call, including the existing TUI {@code permission.request} prompt
+     * for WRITE / EXECUTE levels.
+     *
+     * <p>Known gaps (explicitly tracked):
      * <ul>
-     *   <li>SDK agent uses its own built-in tools, not ace-copilot's 6 tools (Phase 2, #4)</li>
-     *   <li>SDK agent auto-approves its permissions (sidecar uses {@code approveAll}) —
-     *       filesystem / shell side effects bypass {@link PermissionManager} (Phase 2, #4)</li>
-     *   <li>No {@code respondToUserInput} routing — follow-up messages are new
-     *       {@code sendAndWait} calls (Phase 3, #5)</li>
-     *   <li>No planner / self-improvement / checkpoint / compaction hooks</li>
-     *   <li>Cancellation mid-call is best-effort: the request returns after the
-     *       sendAndWait finishes; cancel has no wire-level interrupt yet</li>
+     *   <li>No {@code respondToUserInput} routing — follow-up messages are
+     *       new {@code sendAndWait} calls (Phase 3, #5). Structured-input
+     *       elicitations are auto-declined with a user-visible warning
+     *       until that lands.</li>
+     *   <li>Long-running tool output is delivered as a single
+     *       {@code stream.tool_completed} payload, not incrementally
+     *       (Phase 3 rework, #5).</li>
+     *   <li>No planner / self-improvement / checkpoint / compaction hooks
+     *       on this path (Phase 4, #6).</li>
+     *   <li>Cancellation mid-call is best-effort: the request returns
+     *       after the sendAndWait finishes; cancel has no wire-level
+     *       interrupt yet.</li>
      * </ul>
      */
     private Object handlePromptViaCopilotSession(String sessionId,
@@ -2052,10 +2114,34 @@ public final class StreamingAgentHandler {
         // permission.request round-trip via cancelContext.
         client.setRequestHandler((method, params) -> {
             if ("tool.invoke".equals(method)) {
-                return handleCopilotToolInvoke(params, permissionAwareRegistry);
+                return handleCopilotToolInvoke(params, permissionAwareRegistry, cancelContext, sessionId);
             }
             log.warn("Unhandled sidecar RPC: {}", method);
             throw new IllegalArgumentException("unsupported method: " + method);
+        });
+
+        // Forward session/elicitation_declined notifications from the
+        // sidecar as stream.warning so users see when the SDK agent (or an
+        // MCP server it calls) asked for structured input the runtime
+        // cannot surface yet (#12 until #5 lands a TUI flow for it).
+        client.setNotificationHandler(n -> {
+            if (!"session/elicitation_declined".equals(n.method())) return;
+            try {
+                String what = n.params().path("message").asText("");
+                String src = n.params().path("elicitationSource").asText("");
+                String msg = "Copilot session declined an elicitation request"
+                        + (src.isBlank() ? "" : " from " + src)
+                        + (what.isBlank() ? "" : ": " + what)
+                        + ". This runtime does not yet surface structured form input (see #5).";
+                log.warn(msg);
+                var p = objectMapper.createObjectNode();
+                p.put("level", "warning");
+                p.put("message", msg);
+                p.put("reason", "elicitation_declined");
+                cancelContext.sendNotification("stream.warning", p);
+            } catch (Exception e) {
+                log.debug("Failed to forward elicitation_declined warning: {}", e.getMessage());
+            }
         });
 
         var started = System.currentTimeMillis();

--- a/ace-copilot-daemon/src/test/java/dev/acecopilot/daemon/CopilotToolSignatureTest.java
+++ b/ace-copilot-daemon/src/test/java/dev/acecopilot/daemon/CopilotToolSignatureTest.java
@@ -1,0 +1,83 @@
+package dev.acecopilot.daemon;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.acecopilot.llm.copilot.CopilotAcpClient;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the Java-side tool signature used by {@code StreamingAgentHandler}
+ * to pre-warn on mid-session tool-catalog change (PR #9 review, issue #12).
+ * The sidecar independently computes an equivalent signature — divergence
+ * between the two breaks the pre-warning, so the signature function
+ * deserves unit-level coverage even though the dispatch code doesn't.
+ */
+class CopilotToolSignatureTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static String sig(List<CopilotAcpClient.ToolDescriptor> tools) throws Exception {
+        Method m = StreamingAgentHandler.class
+                .getDeclaredMethod("computeToolSignature", List.class);
+        m.setAccessible(true);
+        return (String) m.invoke(null, tools);
+    }
+
+    private static CopilotAcpClient.ToolDescriptor td(String name, String desc, JsonNode schema) {
+        return new CopilotAcpClient.ToolDescriptor(name, desc, schema);
+    }
+
+    @Test
+    void emptyYieldsStableToken() throws Exception {
+        assertThat(sig(List.of()))
+                .as("an empty tool set must have a deterministic signature that is not mistaken for a name")
+                .isEqualTo("empty");
+    }
+
+    @Test
+    void sameSetDifferentOrderHasSameSignature() throws Exception {
+        var schema = MAPPER.createObjectNode().put("type", "object");
+        var a = List.of(td("read_file", "Read", schema), td("write_file", "Write", schema));
+        var b = List.of(td("write_file", "Write", schema), td("read_file", "Read", schema));
+        assertThat(sig(a))
+                .as("tool list order must not affect signature — sidecar sorts too")
+                .isEqualTo(sig(b));
+    }
+
+    @Test
+    void addingToolChangesSignature() throws Exception {
+        var schema = MAPPER.createObjectNode().put("type", "object");
+        var before = List.of(td("read_file", "Read", schema));
+        var after = List.of(
+                td("read_file", "Read", schema),
+                td("mcp_late_tool", "Async MCP arrival", schema));
+        assertThat(sig(before))
+                .as("an MCP tool arriving between turns must force a signature mismatch → pre-warn")
+                .isNotEqualTo(sig(after));
+    }
+
+    @Test
+    void descriptionChangeIsSignificant() throws Exception {
+        var schema = MAPPER.createObjectNode().put("type", "object");
+        var before = List.of(td("bash", "Run shell", schema));
+        var after = List.of(td("bash", "Run shell with sandboxing", schema));
+        assertThat(sig(before))
+                .as("description matters — agents read descriptions to pick tools, so catalog change includes it")
+                .isNotEqualTo(sig(after));
+    }
+
+    @Test
+    void schemaChangeIsSignificant() throws Exception {
+        var open = MAPPER.createObjectNode().put("type", "object");
+        var strict = MAPPER.createObjectNode().put("type", "object");
+        strict.putArray("required").add("path");
+        var before = List.of(td("read_file", "Read", open));
+        var after = List.of(td("read_file", "Read", strict));
+        assertThat(sig(before)).isNotEqualTo(sig(after));
+    }
+}

--- a/ace-copilot-llm/src/main/java/dev/acecopilot/llm/copilot/CopilotAcpClient.java
+++ b/ace-copilot-llm/src/main/java/dev/acecopilot/llm/copilot/CopilotAcpClient.java
@@ -40,10 +40,10 @@ import java.util.function.Consumer;
  * its own internal ReAct loop inside one call, whereas {@code LlmClient} is
  * request-response at the LLM layer.
  *
- * <p>This is the Phase 1 skeleton (issue #3): no tool registration, no
- * {@code respondToUserInput} routing, no {@code LlmClientFactory} wiring.
- * It is callable from Java but not yet reached by a user prompt through the
- * daemon agent loop.
+ * <p>Phase 2 (#4) wired tool registration + permission bridge and
+ * {@code StreamingAgentHandler} now routes {@code copilotRuntime=session}
+ * prompts through this client end-to-end.
+ * {@code respondToUserInput} routing is the Phase 3 follow-up (#5).
  */
 public final class CopilotAcpClient implements AutoCloseable {
 
@@ -54,7 +54,8 @@ public final class CopilotAcpClient implements AutoCloseable {
 
     /**
      * Handles incoming RPC requests from the sidecar (sidecar → Java). Used
-     * by Phase 2 (#4) for {@code tool.invoke} and {@code permission.request}.
+     * by Phase 2 (#4) for {@code tool.invoke}; Phase 3 (#5) may add
+     * {@code user_input.request} alongside once respondToUserInput lands.
      *
      * <p>Return a {@link JsonNode} to send back as {@code result}; throw to
      * send an {@code error}. Handlers run on a dedicated executor so they
@@ -113,6 +114,7 @@ public final class CopilotAcpClient implements AutoCloseable {
     private final Thread readerThread;
     private final ExecutorService requestExecutor;
     private volatile Consumer<NotificationEvent> notificationHandler;
+    private volatile Consumer<NotificationEvent> extraNotificationHandler;
     private volatile RequestHandler requestHandler;
 
     /**
@@ -259,7 +261,17 @@ public final class CopilotAcpClient implements AutoCloseable {
                     accum.lastUsage = u;
                     accum.usageCount++;
                 }
-                default -> log.debug("ignored notification: {}", n.method());
+                default -> {
+                    // Let callers handle anything we don't know about
+                    // (elicitation declines, tool reset signals, etc.).
+                    var extra = extraNotificationHandler;
+                    if (extra != null) {
+                        try { extra.accept(n); }
+                        catch (RuntimeException e) { log.warn("extra notification handler threw", e); }
+                    } else {
+                        log.debug("ignored notification: {}", n.method());
+                    }
+                }
             }
         };
 
@@ -475,6 +487,17 @@ public final class CopilotAcpClient implements AutoCloseable {
     /** Registers a handler for incoming RPC requests from the sidecar. */
     public void setRequestHandler(RequestHandler handler) {
         this.requestHandler = handler;
+    }
+
+    /**
+     * Registers a handler for notifications beyond the built-in
+     * {@code session/text} and {@code session/usage} streams (e.g.
+     * {@code session/elicitation_declined}). Only fires during an active
+     * {@link #sendAndWait}. Reset to null between turns — the caller
+     * should re-register if it wants per-turn state.
+     */
+    public void setNotificationHandler(Consumer<NotificationEvent> handler) {
+        this.extraNotificationHandler = handler;
     }
 
     @Override

--- a/ace-copilot-sidecar/sidecar.mjs
+++ b/ace-copilot-sidecar/sidecar.mjs
@@ -25,9 +25,12 @@
 //                        premiumUsed, premiumLimit }
 //   - Requests from sidecar → daemon (Phase 2, issue #4):
 //       tool.invoke         { name, arguments } → { content, isError? }
-//       permission.request  { kind, toolName?, fileName?, command?, url?, reason? }
-//                            → { decision: "approved"|"denied-interactively-by-user"
-//                                         |"denied-by-rules", reason? }
+//   - Additional notifications (Pre-Phase 3, issue #12):
+//       session/elicitation_declined
+//                            { mode, message, elicitationSource, url }
+//                            — fired when the SDK agent requests structured
+//                              form input; auto-declined until Phase 3 (#5)
+//                              grows a TUI surface for elicitation + user_input
 //   - Logs go to stderr, not stdout (stdout carries framed JSON-RPC only).
 
 import { CopilotClient, defineTool } from "@github/copilot-sdk";
@@ -207,6 +210,26 @@ async function ensureSession(model, toolDefs) {
           kind: "denied-by-rules",
           reason: `kind="${req?.kind}" is not allowed under the ace-copilot custom-tool allowlist.`,
         };
+      },
+      // Pre-Phase 3 (#12): structured-form input from MCP servers or the
+      // SDK agent. We do not yet have a TUI surface for elicitation
+      // (Phase 3, #5 will land respondToUserInput / respondToElicitation
+      // together), so decline deterministically and surface a warning up
+      // to the TUI. Silent decline was the default before — explicit
+      // decline + notification makes the behavior visible.
+      onElicitationRequest: async (ctx) => {
+        writeMessage({
+          jsonrpc: "2.0",
+          method: "session/elicitation_declined",
+          params: {
+            mode: ctx?.mode ?? null,
+            message: ctx?.message ?? null,
+            elicitationSource: ctx?.elicitationSource ?? null,
+            url: ctx?.url ?? null,
+          },
+        });
+        log(`elicitation auto-declined: mode=${ctx?.mode} source=${ctx?.elicitationSource}`);
+        return { action: "decline", content: {} };
       },
     };
     if (aceCopilotTools.length > 0) {

--- a/docs/copilot-session-runtime.md
+++ b/docs/copilot-session-runtime.md
@@ -1,0 +1,133 @@
+# Copilot session runtime
+
+`copilotRuntime: "session"` routes Copilot-provider prompts through
+`@github/copilot-sdk` via a Node sidecar so the SDK agent's internal
+ReAct loop runs inside **one** billable `sendAndWait` per user prompt,
+regardless of how many tool calls or LLM iterations happen inside. Same
+work that costs 5 premium requests on the `/chat/completions` path
+costs 1 here.
+
+This document is the current contract for operators and reviewers.
+Everything below reflects `main` as of Pre-Phase 3 (#12); follow-ups
+live in issues #5 (Phase 3) and #6 (Phase 4).
+
+## Turning it on
+
+```json
+{
+  "profiles": {
+    "copilot": {
+      "provider": "copilot",
+      "model": "claude-haiku-4.5",
+      "copilotRuntime": "session",
+      "apiKey": "<GitHub OAuth or PAT with Copilot entitlement>"
+    }
+  }
+}
+```
+
+Defaults to `"chat"` — existing installs see no change. The legacy
+`copilotRuntimeAcceptUnsandboxed` field is accepted for backward compat
+but is a no-op; daemon logs an info line if it is still present.
+
+## Requirements
+
+- Node.js 20+ on `PATH`. Daemon preflights this at startup; missing
+  Node falls back to `chat` with a pointed ERROR log.
+- The ace-copilot CLI distribution ships the sidecar under
+  `<appHome>/sidecar/` (installed automatically by
+  `installSidecarDeps` during `installDist`).
+- GitHub token resolution reuses `CopilotTokenProvider`: cached OAuth
+  → `apiKey` → `GITHUB_TOKEN` → `GH_TOKEN` → `gh auth token`.
+
+## What's supported
+
+- One long-lived Copilot SDK session per ace-copilot session. Sidecar
+  reuses the SDK session across turns when model + tool catalog are
+  stable.
+- `defineTool` registration of ace-copilot's real tools (6 core +
+  MCP / memory / skill / extras). The sidecar also installs an
+  `onPreToolUse` allowlist that blocks every SDK built-in so
+  ace-copilot is the only tool surface.
+- Permission enforcement via `PermissionAwareTool` → `PermissionManager`
+  → existing TUI `permission.request` round-trip for WRITE / EXECUTE.
+  Sidecar's `onPermissionRequest` only approves `custom-tool` kinds;
+  everything else (shell / mcp / url / memory / hook directly from the
+  SDK) is denied.
+- Per-turn tool-catalog refresh. The registry is re-evaluated against
+  the live daemon state each prompt, so MCP tools that register
+  asynchronously reach subsequent turns.
+- Remote context-reset warnings surfaced as yellow `[warning: ...]`
+  in the TUI (backed by `stream.warning` on the wire, buffered in
+  `BackgroundOutputBuffer` for `/bg` tasks).
+- Tool activity via `stream.tool_use` / `stream.tool_completed` —
+  parity with the chat path's turn-summary rendering.
+
+## Intentionally deferred
+
+| Area | Status | Tracked in |
+| --- | --- | --- |
+| `respondToUserInput` routing (follow-up messages cost 0 premium) | Not implemented — each follow-up is a new billable `sendAndWait` | #5 |
+| Structured-form elicitation (MCP etc.) | Auto-declined + yellow warning in TUI | #5 |
+| Incremental mid-execution output for long-running tools (`bash`, etc.) | One `stream.tool_completed` payload at the end, not streamed | #5 |
+| TaskPlanner consolidated inside the session | Still runs via separate LLM calls | #6 |
+| SelfImprovementEngine (`ErrorDetector`, `PatternDetector`) | Separate LLM calls | #6 |
+| Cancel with wire-level interrupt | Best-effort; cancel takes effect after the current `sendAndWait` | #5 |
+
+## Diagnostic fields
+
+Every session-path JSON-RPC response includes `result.usage.copilot`:
+
+| Field | Meaning |
+| --- | --- |
+| `runtime` | Always `"session"` on this path. Useful if a tool renders output from multiple runtimes. |
+| `usageEventCount` | Number of `assistant.usage` events observed inside this turn. >1 means the SDK agent ran multiple internal LLM calls (typically 1 initial + N tool-result continuations). All of them together cost one premium request. |
+| `premiumUsedBefore` / `premiumUsedAfter` | Snapshots of `premium_interactions.usedRequests` at the first and last `assistant.usage` events of the turn. Useful for operators wanting raw numbers. |
+| `previousTurnPremiumUsed` | The `lastUsage.premiumUsed` stored from the **previous** turn on this session. Baseline for the honest cross-turn delta. |
+| `premiumDeltaSinceLastTurn` | **Authoritative per-turn billing signal.** `currentTurn.last.premiumUsed - previousTurnPremiumUsed`. `>0` iff the turn incurred a premium request. `-1` if no baseline yet (first turn of a session). |
+| `intraTurnPremiumDelta` | Diagnostic only. Subtraction inside the turn (`last - first`). The SDK does not guarantee `first` is a pre-billing baseline — GitHub's counter updates asynchronously and can land mid-stream, so this alone can report 0 for a billable turn or vice-versa. Use `premiumDeltaSinceLastTurn`. |
+| `initiatorFirst` / `initiatorLast` | `"user"` for the initial turn kickoff, `"agent"` for SDK-driven continuations. |
+| `wallMs` | Total wall time of the turn. |
+
+### `stream.warning` reasons
+
+| `reason` | When |
+| --- | --- |
+| (unset) | Legacy pre-Phase-2 warnings (model change, etc.) |
+| `tool_catalog_changed` | The tool set shifted between turns; remote SDK session was recreated and prior Copilot context discarded. Local transcript still reads continuously. |
+| `elicitation_declined` | The SDK (or an MCP server it invoked) requested structured-form input, which this runtime cannot surface yet. Auto-declined. |
+
+## Billing verification
+
+Authoritative: GitHub's `premium_interactions.usedRequests` delta over
+time. To compute what a session actually billed locally:
+
+```bash
+grep "Copilot session turn" ~/.ace-copilot/logs/daemon.log | tail -50 | \
+  awk -F'premiumUsed=' '{split($2, a, "->"); \
+    gsub(/[^0-9]/, "", a[1]); gsub(/[^0-9]/, "", a[2]); \
+    if(!first) first=a[1]; last=a[2]} \
+    END {print "session billing delta: " (last - first)}'
+```
+
+This matches `https://github.com/settings/copilot/usage` up to the
+dashboard's propagation lag (minutes to hours).
+
+## Troubleshooting
+
+- **"copilotRuntime='session' requires Node.js on PATH"** at startup:
+  install Node 20+ (`brew install node`, `nvm install 20`, etc.) and
+  restart the daemon. Until then the daemon stays on `chat`.
+- **"copilotRuntime='session' requires a sidecar directory"** at
+  prompt time: the distribution is missing its `sidecar/` subtree.
+  Set `ACE_COPILOT_SIDECAR_DIR` to a populated sidecar or rebuild the
+  CLI distribution (`./gradlew :ace-copilot-cli:installDist`).
+- **Agent answers without using tools even though you asked it to**:
+  the SDK agent decides tool use on its own; our registration +
+  allowlist only constrain *which* tools it can use. A prompt that
+  explicitly says "Use tools" usually coaxes it.
+- **`premiumDeltaSinceLastTurn: -1` on every turn**: the daemon's
+  per-session baseline map is keyed on `sessionId`. If you destroy +
+  recreate the ace-copilot session between prompts, each new prompt
+  is a first turn with no baseline. Long-running TUI sessions should
+  show real deltas after the first turn.


### PR DESCRIPTION
## Summary

Pre-Phase 3 (#12) edge-hardening pass. Keeps the current Phase 2 session runtime operationally trustworthy before \`respondToUserInput\` (#5) lands.

## What changes

- **Elicitation handler**: sidecar wires \`onElicitationRequest\` → deterministic decline + \`session/elicitation_declined\` notification → daemon forwards as \`stream.warning\` with \`reason: \"elicitation_declined\"\`. Silent fallthrough is gone.
- **Tool-use visibility**: \`handleCopilotToolInvoke\` emits \`stream.tool_use\` (pre-exec, with the same \`summarizeToolInput\` the chat path uses) and \`stream.tool_completed\` (post-exec, with \`durationMs\` + \`isError\` + error text). TUI parity with the chat path for tool activity; full incremental mid-execution streaming stays deferred to #5.
- **Notification extensibility**: \`CopilotAcpClient\` grows \`setNotificationHandler\` so callers can handle notifications beyond the built-in \`session/text\` + \`session/usage\` (elicitation today, Phase 3 user_input events later).
- **Stale comments**: \`CopilotAcpClient\` javadoc no longer claims Phase 1 skeleton. \`handlePromptViaCopilotSession\` gap list rewritten to describe what actually ships (Phase 2) vs what's still deferred (#5 / #6).
- **Contract doc**: new \`docs/copilot-session-runtime.md\` — supported features, explicit gaps mapped to issues, \`usage.copilot\` field glossary (including the \`premiumDeltaSinceLastTurn\` vs \`intraTurnPremiumDelta\` distinction that kept coming up in review), local billing verification snippet, troubleshooting.
- **Regression tests**:
  - \`CopilotToolSignatureTest\` — pins the pre-warn trigger conditions (name add, description change, schema change, order-insensitivity).
  - \`BackgroundOutputBufferWarningTest\` — pins that \`onWarning\` buffers a \`Warning\` event and \`extractTextContent\` surfaces it, so Phase 3 adding more warning sites can't silently regress the \`/bg\` path.

## Evidence

\`./gradlew build\` green locally (macOS); new tests pass alongside the existing Copilot smoke + gate + cross-turn tests. Daemon end-to-end smoke against real \`@github/copilot-sdk\` continues to work.

## Acceptance criteria (#12)

- [x] Elicitation requests have an explicit, deterministic outcome (auto-decline + user-visible warning, documented in the contract doc)
- [x] Tool activity on the session path emits \`stream.tool_use\` / \`stream.tool_completed\`; incremental mid-execution streaming gap is explicitly called out in javadoc + doc with #5 as the owner
- [x] No Phase-1-era comments remain that materially misdescribe the active session runtime
- [x] Review-driven fixes (pre-warn trigger, cross-turn premium delta, \`/bg\` warning survival) have tests that would fail on the previously reviewed regressions
- [x] User-facing note in \`docs/\` explaining the current session-runtime feature envelope + diagnostic fields

## Non-goals (still)

- \`respondToUserInput\` routing (Phase 3, #5)
- Incremental mid-execution tool output (Phase 3, #5)
- Planner / self-improvement consolidation (Phase 4, #6)

## Test plan

- [x] \`./gradlew build\` passes
- [x] New unit tests pass
- [ ] Reviewer: open the TUI with session runtime, send a prompt that exercises read_file / bash — stream.tool_use and stream.tool_completed both render
- [ ] Reviewer: scan \`docs/copilot-session-runtime.md\` and flag anything the runtime does NOT do that the doc claims it does

🤖 Generated with [Claude Code](https://claude.com/claude-code)