### PR TITLE
feat(copilot): phase 3 user_input routing — foundation (c1+c2, #5)

### DIFF
--- a/ace-copilot-cli/src/main/java/dev/acecopilot/cli/ForegroundOutputSink.java
+++ b/ace-copilot-cli/src/main/java/dev/acecopilot/cli/ForegroundOutputSink.java
@@ -201,6 +201,36 @@ public final class ForegroundOutputSink implements OutputSink {
     }
 
     @Override
+    public void onUserInputRequest(String requestId, String question,
+                                   java.util.List<String> choices,
+                                   boolean allowFreeform) {
+        synchronized (lock) {
+            if (receivedTextOutput) {
+                flushMarkdown();
+            }
+            stopSpinnerInternal();
+            statusRenderer.hide();
+            out.printf("%s[waiting for clarification]%s%n", ACCENT, RESET);
+            out.flush();
+            statusRenderer.refresh();
+        }
+    }
+
+    @Override
+    public void onUserInputResolved(String requestId, String reason) {
+        synchronized (lock) {
+            statusRenderer.hide();
+            if (reason == null) {
+                out.printf("%s[answer received — continuing]%s%n", MUTED, RESET);
+            } else {
+                out.printf("%s[clarification %s]%s%n", MUTED, reason, RESET);
+            }
+            out.flush();
+            statusRenderer.refresh();
+        }
+    }
+
+    @Override
     public void onStreamCancelled() {
         synchronized (lock) {
             stopSpinnerInternal();

--- a/ace-copilot-cli/src/main/java/dev/acecopilot/cli/OutputSink.java
+++ b/ace-copilot-cli/src/main/java/dev/acecopilot/cli/OutputSink.java
@@ -53,6 +53,28 @@ public interface OutputSink {
      */
     default void onWarning(String message) {}
 
+    /**
+     * The Copilot session-runtime agent is blocked on a clarifying
+     * question (Phase 3, #5). Foreground sinks render the question so the
+     * user's next input can be routed as an answer (0 premium request)
+     * instead of a new prompt (1 premium request).
+     *
+     * @param requestId     opaque id that must be echoed back in the answer
+     * @param question      text the agent is asking
+     * @param choices       predefined answers; may be empty
+     * @param allowFreeform whether a free-form answer is acceptable
+     */
+    default void onUserInputRequest(String requestId, String question,
+                                    java.util.List<String> choices,
+                                    boolean allowFreeform) {}
+
+    /**
+     * The pending {@link #onUserInputRequest} has been resolved (answered,
+     * cancelled, or superseded). Foreground sinks clear the waiting-for-
+     * clarification indicator. {@code null} reason means a normal answer.
+     */
+    default void onUserInputResolved(String requestId, String reason) {}
+
     /** Receives a stream cancellation acknowledgment. */
     void onStreamCancelled();
 

--- a/ace-copilot-cli/src/main/java/dev/acecopilot/cli/TaskManager.java
+++ b/ace-copilot-cli/src/main/java/dev/acecopilot/cli/TaskManager.java
@@ -55,6 +55,21 @@ public final class TaskManager {
     public TaskHandle submit(String prompt, DaemonConnection connection, String sessionId,
                              OutputSink outputSink, PermissionBridge permissionBridge,
                              int contextWindow) {
+        return submit(prompt, connection, sessionId, outputSink,
+                permissionBridge, null, contextWindow);
+    }
+
+    /**
+     * Overload accepting a {@link UserInputBridge} so Copilot session-runtime
+     * clarifications ({@code user_input.requested}) can be answered by the
+     * REPL thread. Without a bridge, {@link TaskStreamReader} auto-cancels
+     * any clarification with a visible warning (safe fallback — no
+     * deadlock). See Phase 3, #5.
+     */
+    public TaskHandle submit(String prompt, DaemonConnection connection, String sessionId,
+                             OutputSink outputSink, PermissionBridge permissionBridge,
+                             UserInputBridge userInputBridge,
+                             int contextWindow) {
         Objects.requireNonNull(prompt, "prompt");
         Objects.requireNonNull(connection, "connection");
         Objects.requireNonNull(sessionId, "sessionId");
@@ -67,7 +82,7 @@ public final class TaskManager {
 
         // TaskStreamReader reads sink from handle.outputSink() — supports /bg and /fg swaps
         var reader = new TaskStreamReader(handle, connection, sessionId,
-                prompt, permissionBridge, this::handleTaskComplete);
+                prompt, permissionBridge, userInputBridge, this::handleTaskComplete);
 
         Thread thread = Thread.ofVirtual()
                 .name("ace-copilot-task-" + taskId)

--- a/ace-copilot-cli/src/main/java/dev/acecopilot/cli/TaskStreamReader.java
+++ b/ace-copilot-cli/src/main/java/dev/acecopilot/cli/TaskStreamReader.java
@@ -27,6 +27,15 @@ public final class TaskStreamReader implements Runnable {
      */
     static final long CLIENT_PERMISSION_WAIT_TIMEOUT_MS = 115_000L;
 
+    /**
+     * Phase 3 (#5) c5: how long this side waits for a REPL answer to a
+     * Copilot clarification before auto-cancelling. 5 minutes matches the
+     * product intent ("user walked away, don't wedge the sidecar"). The
+     * daemon-side sendAndWait has no deadline so this is the canonical
+     * timer for the interaction.
+     */
+    static final long CLIENT_USER_INPUT_WAIT_TIMEOUT_MS = 5 * 60 * 1000L;
+
     private final TaskHandle handle;
     private final DaemonConnection connection;
     private final String sessionId;
@@ -301,16 +310,17 @@ public final class TaskStreamReader implements Runnable {
                 handle.taskId(), requestId, question, choices, allowFreeform);
         UserInputBridge.UserInputAnswer answer;
         try {
-            // No timeout here — Phase 3 c5 adds a configurable one.
-            answer = userInputBridge.requestInput(req, 0, null);
+            answer = userInputBridge.requestInput(req,
+                    CLIENT_USER_INPUT_WAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             sink.onUserInputResolved(requestId, "interrupted");
             autoCancelUserInput(requestId, question, "interrupted while waiting for user");
             return;
-        } catch (java.util.concurrent.TimeoutException e) {
+        } catch (TimeoutException e) {
             sink.onUserInputResolved(requestId, "timeout");
-            autoCancelUserInput(requestId, question, "timed out waiting for user");
+            autoCancelUserInput(requestId, question,
+                    "timed out after " + (CLIENT_USER_INPUT_WAIT_TIMEOUT_MS / 1000) + "s with no answer");
             return;
         }
 

--- a/ace-copilot-cli/src/main/java/dev/acecopilot/cli/TaskStreamReader.java
+++ b/ace-copilot-cli/src/main/java/dev/acecopilot/cli/TaskStreamReader.java
@@ -183,6 +183,7 @@ public final class TaskStreamReader implements Runnable {
                     }
                 }
             }
+            case "user_input.requested" -> handleUserInputRequested(params);
             case "stream.heartbeat" -> {
                 String phase = "active";
                 if (params != null) {
@@ -242,6 +243,46 @@ public final class TaskStreamReader implements Runnable {
                 sink.onBudgetExhausted(params);
             }
             default -> log.debug("Task {}: ignoring notification: {}", handle.taskId(), method);
+        }
+    }
+
+    /**
+     * Phase 3 (#5) landing in stages: the daemon's
+     * {@code handleSidecarUserInputRequest} blocks inside the in-flight
+     * {@code sendAndWait} until it receives a {@code user_input.response}
+     * notification on this connection. The current CLI does not yet have
+     * a clarification UX (arriving in c3 along with
+     * {@code /new <prompt>}), so auto-cancel immediately to avoid
+     * deadlocking the session. The user sees a yellow warning explaining
+     * what happened; the agent wraps the turn with a short decline.
+     */
+    private void handleUserInputRequested(JsonNode params) {
+        if (params == null) return;
+        String requestId = params.path("requestId").asText("");
+        if (requestId.isEmpty()) {
+            log.warn("Task {}: user_input.requested missing requestId — cannot auto-cancel", handle.taskId());
+            return;
+        }
+        String question = params.path("question").asText("");
+        String summary = question.isBlank()
+                ? "Copilot agent asked a clarifying question"
+                : "Copilot agent asked: " + question;
+        String warning = summary + ". This CLI does not yet route answers back "
+                + "(Phase 3 work-in-progress, #5); auto-cancelling so the session does not hang.";
+        handle.appendToolEvent("stream", "user_input_auto_cancel", false, 0, warning);
+        handle.markActivity("user_input auto-cancelled");
+        handle.outputSink().onWarning(warning);
+
+        try {
+            ObjectNode responseParams = connection.objectMapper().createObjectNode();
+            responseParams.put("requestId", requestId);
+            responseParams.put("cancel", true);
+            responseParams.put("answer", "");
+            responseParams.put("wasFreeform", true);
+            connection.sendNotification("user_input.response", responseParams);
+        } catch (IOException e) {
+            log.error("Task {}: failed to send user_input.response cancel: {}",
+                    handle.taskId(), e.getMessage());
         }
     }
 

--- a/ace-copilot-cli/src/main/java/dev/acecopilot/cli/TaskStreamReader.java
+++ b/ace-copilot-cli/src/main/java/dev/acecopilot/cli/TaskStreamReader.java
@@ -32,17 +32,33 @@ public final class TaskStreamReader implements Runnable {
     private final String sessionId;
     private final String fullPrompt;
     private final PermissionBridge permissionBridge;
+    private final UserInputBridge userInputBridge;
     private final Consumer<TaskHandle> onComplete;
+
+    /**
+     * Phase 1-compatible constructor without {@link UserInputBridge}; any
+     * {@code user_input.requested} notification gets auto-cancelled so the
+     * sendAndWait does not hang. New code should pass a bridge so the REPL
+     * can actually answer the question (Phase 3, #5).
+     */
+    public TaskStreamReader(TaskHandle handle, DaemonConnection connection,
+                            String sessionId, String fullPrompt,
+                            PermissionBridge permissionBridge,
+                            Consumer<TaskHandle> onComplete) {
+        this(handle, connection, sessionId, fullPrompt, permissionBridge, null, onComplete);
+    }
 
     public TaskStreamReader(TaskHandle handle, DaemonConnection connection,
                             String sessionId, String fullPrompt,
                             PermissionBridge permissionBridge,
+                            UserInputBridge userInputBridge,
                             Consumer<TaskHandle> onComplete) {
         this.handle = Objects.requireNonNull(handle, "handle");
         this.connection = Objects.requireNonNull(connection, "connection");
         this.sessionId = Objects.requireNonNull(sessionId, "sessionId");
         this.fullPrompt = Objects.requireNonNull(fullPrompt, "fullPrompt");
         this.permissionBridge = Objects.requireNonNull(permissionBridge, "permissionBridge");
+        this.userInputBridge = userInputBridge;
         this.onComplete = onComplete;
     }
 
@@ -247,32 +263,80 @@ public final class TaskStreamReader implements Runnable {
     }
 
     /**
-     * Phase 3 (#5) landing in stages: the daemon's
-     * {@code handleSidecarUserInputRequest} blocks inside the in-flight
-     * {@code sendAndWait} until it receives a {@code user_input.response}
-     * notification on this connection. The current CLI does not yet have
-     * a clarification UX (arriving in c3 along with
-     * {@code /new <prompt>}), so auto-cancel immediately to avoid
-     * deadlocking the session. The user sees a yellow warning explaining
-     * what happened; the agent wraps the turn with a short decline.
+     * Routes a Copilot clarification (Phase 3, #5) through the
+     * {@link UserInputBridge} so the REPL collects the user's answer and
+     * this thread sends it back as a {@code user_input.response}
+     * notification. The whole exchange stays inside the in-flight
+     * {@code sendAndWait} — cost stays at 0 premium requests.
+     *
+     * <p>When no bridge is registered (pre-#5 wiring paths, test harnesses),
+     * falls back to an immediate cancel so the sendAndWait unwinds with a
+     * visible warning rather than deadlocking.
      */
     private void handleUserInputRequested(JsonNode params) {
         if (params == null) return;
         String requestId = params.path("requestId").asText("");
         if (requestId.isEmpty()) {
-            log.warn("Task {}: user_input.requested missing requestId — cannot auto-cancel", handle.taskId());
+            log.warn("Task {}: user_input.requested missing requestId — cannot route", handle.taskId());
             return;
         }
         String question = params.path("question").asText("");
-        String summary = question.isBlank()
+        boolean allowFreeform = params.path("allowFreeform").asBoolean(true);
+        java.util.List<String> choices = new java.util.ArrayList<>();
+        if (params.has("choices") && params.get("choices").isArray()) {
+            params.get("choices").forEach(c -> { if (c != null && !c.isNull()) choices.add(c.asText()); });
+        }
+
+        if (userInputBridge == null) {
+            autoCancelUserInput(requestId, question,
+                    "This CLI does not have a clarification UX wired (UserInputBridge missing)");
+            return;
+        }
+
+        handle.markActivity("clarification pending");
+        var sink = handle.outputSink();
+        sink.onUserInputRequest(requestId, question, choices, allowFreeform);
+
+        var req = new UserInputBridge.UserInputRequest(
+                handle.taskId(), requestId, question, choices, allowFreeform);
+        UserInputBridge.UserInputAnswer answer;
+        try {
+            // No timeout here — Phase 3 c5 adds a configurable one.
+            answer = userInputBridge.requestInput(req, 0, null);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            sink.onUserInputResolved(requestId, "interrupted");
+            autoCancelUserInput(requestId, question, "interrupted while waiting for user");
+            return;
+        } catch (java.util.concurrent.TimeoutException e) {
+            sink.onUserInputResolved(requestId, "timeout");
+            autoCancelUserInput(requestId, question, "timed out waiting for user");
+            return;
+        }
+
+        String resolvedReason = answer.cancel() ? "cancelled" : null;
+        sink.onUserInputResolved(requestId, resolvedReason);
+
+        try {
+            ObjectNode responseParams = connection.objectMapper().createObjectNode();
+            responseParams.put("requestId", requestId);
+            responseParams.put("cancel", answer.cancel());
+            responseParams.put("answer", answer.answer() != null ? answer.answer() : "");
+            responseParams.put("wasFreeform", answer.wasFreeform());
+            connection.sendNotification("user_input.response", responseParams);
+        } catch (IOException e) {
+            log.error("Task {}: failed to send user_input.response: {}", handle.taskId(), e.getMessage());
+        }
+    }
+
+    private void autoCancelUserInput(String requestId, String question, String reasonMsg) {
+        String prefix = question.isBlank()
                 ? "Copilot agent asked a clarifying question"
                 : "Copilot agent asked: " + question;
-        String warning = summary + ". This CLI does not yet route answers back "
-                + "(Phase 3 work-in-progress, #5); auto-cancelling so the session does not hang.";
+        String warning = prefix + ". " + reasonMsg + " — cancelling so the session does not hang.";
         handle.appendToolEvent("stream", "user_input_auto_cancel", false, 0, warning);
         handle.markActivity("user_input auto-cancelled");
         handle.outputSink().onWarning(warning);
-
         try {
             ObjectNode responseParams = connection.objectMapper().createObjectNode();
             responseParams.put("requestId", requestId);

--- a/ace-copilot-cli/src/main/java/dev/acecopilot/cli/TerminalRepl.java
+++ b/ace-copilot-cli/src/main/java/dev/acecopilot/cli/TerminalRepl.java
@@ -104,6 +104,12 @@ public final class TerminalRepl {
     private final TerminalMarkdownRenderer markdownRenderer;
     private final TaskManager taskManager;
     private final PermissionBridge permissionBridge;
+    private final UserInputBridge userInputBridge = new UserInputBridge();
+    // Phase 3 (#5): set when the user types `/new <prompt>` during a
+    // Copilot clarification. Consumed on the next iteration of the
+    // read-loop so the prompt flows through the normal task-launch path
+    // without us needing to thread the task machinery down here.
+    private volatile String pendingFollowupPrompt;
     private final ObjectMapper statusMapper;
     private final ConcurrentLinkedQueue<UiEvent> uiEvents = new ConcurrentLinkedQueue<>();
     private final Deque<UiNotice> uiNoticeBuffer = new ArrayDeque<>();
@@ -462,12 +468,21 @@ public final class TerminalRepl {
                 notifyCompletedBackgroundTasks(out);
 
                 String line;
+                // Phase 3 (#5): consume any prompt queued by an in-clarification
+                // `/new <prompt>` before blocking on stdin so the new task
+                // starts immediately.
+                String queuedFollowup = pendingFollowupPrompt;
+                if (queuedFollowup != null) {
+                    pendingFollowupPrompt = null;
+                }
                 try {
                     readingPrompt = true;
                     consoleMode = ConsoleMode.NORMAL_INPUT;
                     requestUiRender();
                     try {
-                        line = reader.readLine(PROMPT_STR);
+                        line = (queuedFollowup != null)
+                                ? queuedFollowup
+                                : reader.readLine(PROMPT_STR);
                     } finally {
                         readingPrompt = false;
                         ensureCursorVisible();
@@ -512,6 +527,25 @@ public final class TerminalRepl {
                 }
 
                 String trimmed = line.trim();
+
+                // Phase 3 (#5) `/new [<prompt>]`: explicit new-task escape.
+                // Without a task running, `/new X` is equivalent to `X` since
+                // every new prompt already starts a new agent.prompt. The
+                // useful semantics (cancelling a pending clarification and
+                // starting fresh) live on handleUserInputFromBridge — this
+                // branch just handles the tail.
+                if (trimmed.equalsIgnoreCase("/new")
+                        || trimmed.toLowerCase().startsWith("/new ")) {
+                    String rest = trimmed.length() > 4 ? trimmed.substring(5).trim() : "";
+                    if (rest.isEmpty()) {
+                        out.println(MUTED + "  Ready for your next task." + RESET);
+                        out.flush();
+                        continue;
+                    }
+                    submitAndWait(out, reader, rest);
+                    continue;
+                }
+
                 if (trimmed.startsWith("/")) {
                     if (handleSlashCommand(out, trimmed, reader)) {
                         break;
@@ -1044,7 +1078,8 @@ public final class TerminalRepl {
 
             promptStartNanos = System.nanoTime();
 
-            var handle = taskManager.submit(effectiveInput, conn, sessionId, fgSink, permissionBridge, ctxWindow);
+            var handle = taskManager.submit(effectiveInput, conn, sessionId, fgSink,
+                    permissionBridge, userInputBridge, ctxWindow);
             taskManager.setForeground(handle.taskId());
             resumeCheckpointStore.recordTaskSubmitted(
                     sessionId,
@@ -1130,6 +1165,15 @@ public final class TerminalRepl {
                     continue;
                 }
 
+                // 1b. Handle Copilot session clarification (Phase 3, #5).
+                var uiReq = userInputBridge.pollPending();
+                if (uiReq != null) {
+                    terminal.setAttributes(savedAttrs);
+                    handleUserInputFromBridge(out, reader, uiReq);
+                    terminal.setAttributes(rawAttrs);
+                    continue;
+                }
+
                 // 2. Check if user pressed a key (1ms peek — non-blocking)
                 int ch = terminal.reader().peek(1);
                 if (ch == -1) {
@@ -1171,6 +1215,11 @@ public final class TerminalRepl {
                 var permReq = permissionBridge.pollPending(50, TimeUnit.MILLISECONDS);
                 if (permReq != null) {
                     handlePermissionFromBridge(out, reader, permReq);
+                    continue;
+                }
+                var uiReq = userInputBridge.pollPending();
+                if (uiReq != null) {
+                    handleUserInputFromBridge(out, reader, uiReq);
                 }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
@@ -1340,6 +1389,64 @@ public final class TerminalRepl {
      * Handles a permission request routed through the bridge.
      * Prompts the user and submits the answer back.
      */
+    /**
+     * Prompts the user for a clarification answer in the Copilot session
+     * runtime (Phase 3, #5). Plain text is submitted as a free-form answer
+     * (0 premium). Typing {@code /new <prompt>} cancels the clarification
+     * and queues a fresh task — the caller sees the next task start on
+     * the next REPL iteration. Typing {@code /new} alone cancels without
+     * queuing anything (the session idles in "Task complete" state until
+     * the next input).
+     */
+    private void handleUserInputFromBridge(PrintWriter out, LineReader reader,
+                                           UserInputBridge.UserInputRequest req) {
+        out.println();
+        out.println(ACCENT + "━ Copilot agent is asking ━" + RESET);
+        if (!req.question().isBlank()) {
+            out.println("  " + req.question());
+        }
+        if (!req.choices().isEmpty()) {
+            out.println(MUTED + "  choices: " + String.join(" | ", req.choices()) + RESET);
+        }
+        out.println(MUTED + "  (plain text answers; `/new <prompt>` starts a fresh task, `/new` cancels)" + RESET);
+        out.print(ACCENT + " answer > " + RESET);
+        out.flush();
+
+        String line;
+        try {
+            line = reader.readLine("");
+        } catch (Exception e) {
+            userInputBridge.cancel(req.requestId());
+            return;
+        }
+        if (line == null) {
+            userInputBridge.cancel(req.requestId());
+            return;
+        }
+        String trimmed = line.trim();
+
+        if (trimmed.equalsIgnoreCase("/new") || trimmed.toLowerCase().startsWith("/new ")) {
+            userInputBridge.cancel(req.requestId());
+            String rest = trimmed.length() > 4 ? trimmed.substring(5).trim() : "";
+            if (!rest.isEmpty()) {
+                pendingFollowupPrompt = rest;
+                out.println(INFO + "  Clarification cancelled. Starting new task: " + rest + RESET);
+            } else {
+                out.println(INFO + "  Clarification cancelled. Ready for your next input." + RESET);
+            }
+            out.flush();
+            return;
+        }
+
+        boolean isChoice = req.choices().stream().anyMatch(c -> c.equalsIgnoreCase(trimmed));
+        var answer = isChoice
+                ? UserInputBridge.UserInputAnswer.choice(trimmed)
+                : UserInputBridge.UserInputAnswer.freeform(trimmed);
+        if (!userInputBridge.submitAnswer(req.requestId(), answer)) {
+            log.warn("UserInputBridge rejected answer for requestId={}", req.requestId());
+        }
+    }
+
     private void handlePermissionFromBridge(PrintWriter out, LineReader reader,
                                             PermissionBridge.PermissionRequest req) {
         // Inner width excludes the left and right border characters (│ ... │)
@@ -3057,6 +3164,7 @@ public final class TerminalRepl {
                 out.println(INFO + "  /fg" + RESET + "       Bring background task to foreground (/fg [id])");
                 out.println(INFO + "  /continue" + RESET + " Continue from the last task context");
                 out.println(INFO + "  /cancel" + RESET + "   Cancel a task (/cancel [id])");
+                out.println(INFO + "  /new" + RESET + "      Start a fresh task (/new <prompt> to submit immediately; /new alone clears clarification state)");
                 out.println(INFO + "  /exit" + RESET + "     Exit the REPL");
                 out.println();
                 out.flush();

--- a/ace-copilot-cli/src/main/java/dev/acecopilot/cli/TerminalRepl.java
+++ b/ace-copilot-cli/src/main/java/dev/acecopilot/cli/TerminalRepl.java
@@ -123,6 +123,7 @@ public final class TerminalRepl {
     private static final int MAX_CONTEXT_DETAIL_CHARS = 12_000;
     private final Object uiRenderLock = new Object();
     private final AtomicBoolean permissionInterruptRequested = new AtomicBoolean(false);
+    private final AtomicBoolean userInputInterruptRequested = new AtomicBoolean(false);
     private final AtomicBoolean uiRenderRequested = new AtomicBoolean(true);
 
     /** Tracks the effective model, updated after successful model switches. */
@@ -422,6 +423,7 @@ public final class TerminalRepl {
                 pushBackgroundCompletion(handle, reader);
             });
             permissionBridge.setRequestListener(req -> onPermissionRequested(req, reader));
+            userInputBridge.setRequestListener(req -> onUserInputRequested(req, reader));
 
             // Render startup banner
             renderBanner(out, terminal.getWidth());
@@ -498,6 +500,17 @@ public final class TerminalRepl {
                     if (permissionInterruptRequested.getAndSet(false) || permissionBridge.hasPending()) {
                         out.println();
                         drainPermissions(out, reader);
+                        continue;
+                    }
+                    // Same pattern for Copilot clarifications from a
+                    // backgrounded task (Phase 3, #5): an ask_user that
+                    // arrives while the user is back at the main prompt
+                    // must break the readLine, surface the question, and
+                    // route the answer — otherwise the SDK's Promise sits
+                    // in the bridge until the 5-minute timeout fires.
+                    if (userInputInterruptRequested.getAndSet(false) || userInputBridge.hasPending()) {
+                        out.println();
+                        drainUserInputs(out, reader);
                         continue;
                     }
                     // Ctrl+C at prompt: exit gracefully
@@ -1589,6 +1602,23 @@ public final class TerminalRepl {
     }
 
     /**
+     * Phase 3 (#5): drains any pending Copilot clarifications at the
+     * main prompt (when no task is in the foreground). Mirrors
+     * {@link #drainPermissions}; relies on {@link #handleUserInputFromBridge}
+     * to surface the question and collect the answer. Called when the
+     * user's readLine was interrupted by a pending request arriving from
+     * a backgrounded task.
+     */
+    private void drainUserInputs(PrintWriter out, LineReader reader) {
+        while (userInputBridge.hasPending()) {
+            var req = userInputBridge.pollPending();
+            if (req == null) break;
+            handleUserInputFromBridge(out, reader, req);
+            userInputInterruptRequested.set(false);
+        }
+    }
+
+    /**
      * Drains any pending permission requests (non-blocking).
      */
     private void drainPermissions(PrintWriter out, LineReader reader) {
@@ -2146,6 +2176,40 @@ public final class TerminalRepl {
         } catch (Exception e) {
             permissionInterruptRequested.set(false);
             log.debug("Failed to interrupt prompt for permission popup: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * Phase 3 (#5): same shape as {@link #onPermissionRequested} for the
+     * Copilot session runtime's clarification questions. Called from the
+     * {@link UserInputBridge} listener whenever a backgrounded task emits
+     * {@code user_input.requested} and there is no foreground wait loop
+     * to drain it. Raises a SIGINT on the readLine so the main loop's
+     * catch branch routes into {@link #drainUserInputs}.
+     */
+    private void onUserInputRequested(UserInputBridge.UserInputRequest request, LineReader reader) {
+        if (reader == null) return;
+        String summary = request.question() == null || request.question().isBlank()
+                ? "Copilot agent has a clarifying question"
+                : fitWidth(request.question(), 90);
+        String notice = WARNING + "[Clarification] " + RESET
+                + "task #" + request.taskId() + " -> " + summary;
+        enqueueUiNotice(notice);
+        requestUiRender();
+        interruptPromptForUserInputPopup();
+    }
+
+    private void interruptPromptForUserInputPopup() {
+        if (!readingPrompt) return;
+        if (taskManager.hasForegroundTask()) return;
+        if (!userInputInterruptRequested.compareAndSet(false, true)) return;
+        var terminal = activeTerminal;
+        if (terminal == null) return;
+        try {
+            terminal.raise(Terminal.Signal.INT);
+        } catch (Exception e) {
+            userInputInterruptRequested.set(false);
+            log.debug("Failed to interrupt prompt for user_input popup: {}", e.getMessage());
         }
     }
 

--- a/ace-copilot-cli/src/main/java/dev/acecopilot/cli/TerminalRepl.java
+++ b/ace-copilot-cli/src/main/java/dev/acecopilot/cli/TerminalRepl.java
@@ -466,6 +466,16 @@ public final class TerminalRepl {
                 // 1. Check pending permission requests from task threads
                 drainPermissions(out, reader);
 
+                // 1b. Phase 3 (#5): drain Copilot clarifications from
+                // backgrounded tasks proactively — a user_input.requested
+                // that arrives outside the readLine interrupt window (just
+                // after readLine returned, during a permission modal, etc.)
+                // would otherwise sit in UserInputBridge until the 5-minute
+                // timeout. Run this before notifyCompletedBackgroundTasks
+                // so the task in question has a chance to finish its turn
+                // before we render its completion.
+                drainUserInputs(out, reader);
+
                 // 2. Check if any background tasks completed while we were idle
                 notifyCompletedBackgroundTasks(out);
 

--- a/ace-copilot-cli/src/main/java/dev/acecopilot/cli/UserInputBridge.java
+++ b/ace-copilot-cli/src/main/java/dev/acecopilot/cli/UserInputBridge.java
@@ -1,0 +1,139 @@
+package dev.acecopilot.cli;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Phase 3 (#5) sibling of {@link PermissionBridge} for the Copilot
+ * session runtime's clarifying questions.
+ *
+ * <p>When the SDK agent fires {@code ask_user}, the sidecar round-trips
+ * through the daemon, which emits a {@code user_input.requested}
+ * notification on the task connection. {@link TaskStreamReader} surfaces
+ * it here by calling {@link #requestInput}, blocking until the REPL
+ * thread resolves the answer via {@link #submitAnswer} (or cancels with
+ * {@link #cancel}).
+ *
+ * <p>Only one question is expected in-flight per session — the SDK
+ * serializes {@code ask_user} calls — so keyed lookup by {@code requestId}
+ * is defensive rather than structural.
+ */
+public final class UserInputBridge {
+
+    private static final Logger log = LoggerFactory.getLogger(UserInputBridge.class);
+
+    private final BlockingQueue<UserInputRequest> pending = new LinkedBlockingQueue<>();
+    private final ConcurrentHashMap<String, CompletableFuture<UserInputAnswer>> futures =
+            new ConcurrentHashMap<>();
+    private volatile RequestListener requestListener;
+
+    /** Notified on the publishing thread when a new question arrives. */
+    @FunctionalInterface
+    public interface RequestListener {
+        void onUserInputRequested(UserInputRequest request);
+    }
+
+    public void setRequestListener(RequestListener listener) {
+        this.requestListener = listener;
+    }
+
+    /**
+     * Called from {@link TaskStreamReader} when a
+     * {@code user_input.requested} notification arrives. Blocks until the
+     * REPL resolves or cancels the answer.
+     *
+     * @throws InterruptedException if the calling thread is interrupted
+     * @throws TimeoutException     if the timeout elapses with no answer
+     */
+    public UserInputAnswer requestInput(UserInputRequest request, long timeout, TimeUnit unit)
+            throws InterruptedException, TimeoutException {
+        Objects.requireNonNull(request, "request");
+        var future = new CompletableFuture<UserInputAnswer>();
+        var previous = futures.putIfAbsent(request.requestId(), future);
+        if (previous != null) {
+            log.warn("Duplicate user_input requestId {}; reusing existing future", request.requestId());
+            future = previous;
+        }
+        pending.offer(request);
+        var listener = requestListener;
+        if (listener != null) {
+            try { listener.onUserInputRequested(request); }
+            catch (RuntimeException e) { log.warn("UserInputBridge listener threw", e); }
+        }
+        try {
+            return unit == null
+                    ? future.get()
+                    : future.get(timeout, unit);
+        } catch (java.util.concurrent.ExecutionException e) {
+            throw new RuntimeException(e);
+        } finally {
+            futures.remove(request.requestId());
+            pending.remove(request);
+        }
+    }
+
+    /** Resolves a waiting {@link #requestInput} with an answer. */
+    public boolean submitAnswer(String requestId, UserInputAnswer answer) {
+        Objects.requireNonNull(requestId, "requestId");
+        Objects.requireNonNull(answer, "answer");
+        var future = futures.remove(requestId);
+        if (future == null) return false;
+        return future.complete(answer);
+    }
+
+    /** Cancels a waiting {@link #requestInput}. The answer is {@code {cancel: true}}. */
+    public boolean cancel(String requestId) {
+        return submitAnswer(requestId, UserInputAnswer.cancelled());
+    }
+
+    /** Retrieves the next pending request without blocking; {@code null} if none. */
+    public UserInputRequest pollPending() {
+        return pending.poll();
+    }
+
+    /** Peeks at the currently-pending request without removing it; {@code null} if none. */
+    public UserInputRequest peekPending() {
+        return pending.peek();
+    }
+
+    public boolean hasPending() {
+        return !pending.isEmpty();
+    }
+
+    /** Payload delivered to the REPL. */
+    public record UserInputRequest(
+            String taskId,
+            String requestId,
+            String question,
+            List<String> choices,
+            boolean allowFreeform) {
+        public UserInputRequest {
+            Objects.requireNonNull(requestId, "requestId");
+            choices = choices != null ? List.copyOf(choices) : List.of();
+        }
+    }
+
+    /** The REPL's resolution: an answer, or a cancel that declines the clarification. */
+    public record UserInputAnswer(String answer, boolean wasFreeform, boolean cancel) {
+        public static UserInputAnswer freeform(String text) {
+            return new UserInputAnswer(text, true, false);
+        }
+
+        public static UserInputAnswer choice(String text) {
+            return new UserInputAnswer(text, false, false);
+        }
+
+        public static UserInputAnswer cancelled() {
+            return new UserInputAnswer("", true, true);
+        }
+    }
+}

--- a/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/StreamingAgentHandler.java
+++ b/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/StreamingAgentHandler.java
@@ -201,9 +201,10 @@ public final class StreamingAgentHandler {
 
     /**
      * Snapshot of a pending {@code user_input.request} the SDK agent is
-     * blocked on inside a {@code sendAndWait}. {@link #future} is completed
-     * by {@code agent.respondToUserInput} (with an answer) or by
-     * timeout / session teardown (with a cancel).
+     * blocked on inside a {@code sendAndWait}. {@link #future} is owned by
+     * the active {@link CancelAwareStreamContext} — completing it from
+     * elsewhere (e.g. session teardown) unblocks the sidecar-facing
+     * handler thread with a synthetic cancel response.
      */
     record PendingUserInput(
             String sessionId,
@@ -211,11 +212,8 @@ public final class StreamingAgentHandler {
             String question,
             List<String> choices,
             boolean allowFreeform,
-            CompletableFuture<UserInputAnswer> future,
+            CompletableFuture<JsonNode> future,
             long createdAtMs) {}
-
-    /** The user's resolution of a pending {@code user_input.requested}. */
-    record UserInputAnswer(String answer, boolean wasFreeform, boolean cancel) {}
     private volatile String copilotRuntime = "chat";
     private volatile String copilotGithubToken;
     private volatile Path copilotSidecarDir;
@@ -248,52 +246,6 @@ public final class StreamingAgentHandler {
      */
     public void register(RequestRouter router) {
         router.registerStreaming("agent.prompt", this::handlePrompt);
-        router.register("agent.respondToUserInput", this::handleRespondToUserInput);
-    }
-
-    /**
-     * Phase 3 (#5). Resolves a pending {@code user_input.requested} for the
-     * given session so the SDK agent (waiting inside a currently-executing
-     * {@code sendAndWait}) can continue without incurring a new premium
-     * request. Returns quickly — the actual agent work happens in-session.
-     *
-     * <p>Params:
-     * <ul>
-     *   <li>{@code sessionId} — required</li>
-     *   <li>{@code requestId} — required, must match the pending request</li>
-     *   <li>{@code answer} — free-form or choice string; required unless
-     *       {@code cancel} is true</li>
-     *   <li>{@code wasFreeform} — optional, defaults to true</li>
-     *   <li>{@code cancel} — optional; true discards the pending
-     *       question (the SDK agent receives a short decline message so
-     *       it can wrap up the current turn). The caller is responsible
-     *       for any subsequent {@code agent.prompt}.</li>
-     * </ul>
-     */
-    private Object handleRespondToUserInput(JsonNode params) {
-        String sessionId = requireString(params, "sessionId");
-        String requestId = requireString(params, "requestId");
-        boolean cancel = params.path("cancel").asBoolean(false);
-        String answer = params.path("answer").asText("");
-        boolean wasFreeform = params.path("wasFreeform").asBoolean(true);
-
-        var pending = pendingUserInput.get(sessionId);
-        if (pending == null) {
-            throw new IllegalStateException("No pending user_input for session " + sessionId);
-        }
-        if (!pending.requestId().equals(requestId)) {
-            throw new IllegalStateException(
-                    "Stale requestId " + requestId + " for session " + sessionId
-                            + "; current pending requestId is " + pending.requestId());
-        }
-        pendingUserInput.remove(sessionId);
-        pending.future().complete(new UserInputAnswer(answer, wasFreeform, cancel));
-
-        var result = objectMapper.createObjectNode();
-        result.put("sessionId", sessionId);
-        result.put("requestId", requestId);
-        result.put("resolved", cancel ? "cancelled" : "answered");
-        return result;
     }
 
     private Object handlePrompt(JsonNode params, StreamContext context) throws Exception {
@@ -2033,10 +1985,10 @@ public final class StreamingAgentHandler {
     private JsonNode handleSidecarUserInputRequest(JsonNode params,
                                                     CancelAwareStreamContext cancelContext,
                                                     String sessionId) throws Exception {
-        String requestId = params.path("requestId").asText(null);
-        if (requestId == null || requestId.isBlank()) {
-            requestId = UUID.randomUUID().toString();
-        }
+        String incomingRequestId = params.path("requestId").asText(null);
+        final String requestId = (incomingRequestId == null || incomingRequestId.isBlank())
+                ? UUID.randomUUID().toString()
+                : incomingRequestId;
         String question = params.path("question").asText("");
         boolean allowFreeform = params.path("allowFreeform").asBoolean(true);
         List<String> choices = new ArrayList<>();
@@ -2046,16 +1998,11 @@ public final class StreamingAgentHandler {
             });
         }
 
-        var future = new CompletableFuture<UserInputAnswer>();
-        var existing = pendingUserInput.putIfAbsent(sessionId,
-                new PendingUserInput(sessionId, requestId, question, choices,
-                        allowFreeform, future, System.currentTimeMillis()));
-        if (existing != null) {
-            // Should not happen — the SDK serializes questions — but surface
-            // it rather than corrupting state by silently overwriting.
-            throw new IllegalStateException(
-                    "user_input.request collided with an existing pending question for session " + sessionId);
-        }
+        var responseFuture = cancelContext.registerUserInputRequest(requestId);
+        var metaFuture = responseFuture; // alias for cleanup path below
+        pendingUserInput.put(sessionId, new PendingUserInput(
+                sessionId, requestId, question, List.copyOf(choices),
+                allowFreeform, responseFuture, System.currentTimeMillis()));
 
         try {
             var notif = objectMapper.createObjectNode();
@@ -2068,34 +2015,43 @@ public final class StreamingAgentHandler {
             cancelContext.sendNotification("user_input.requested", notif);
         } catch (IOException e) {
             pendingUserInput.remove(sessionId);
+            cancelContext.unregisterUserInputRequest(requestId);
             throw new RuntimeException("Failed to emit user_input.requested: " + e.getMessage(), e);
         }
 
-        UserInputAnswer resolution;
+        JsonNode response;
         try {
-            // Block until the TUI (or a timeout) resolves the future.
-            // The request-dispatch executor is cached / unbounded so
-            // sitting on this thread is acceptable. Phase 3 c5 will add
-            // a configurable timeout here.
-            resolution = future.get();
+            // Block until the TUI's user_input.response notification is
+            // routed to us (or session teardown cancels the future).
+            // Request-dispatch executor is cached, so parking this thread
+            // is acceptable. Phase 3 c5 adds a configurable timeout.
+            response = metaFuture.get();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             pendingUserInput.remove(sessionId);
+            cancelContext.unregisterUserInputRequest(requestId);
             throw new IOException("Interrupted while awaiting user_input answer", e);
         } catch (ExecutionException e) {
             pendingUserInput.remove(sessionId);
             throw new IOException("user_input future failed: " + e.getMessage(), e);
+        } finally {
+            pendingUserInput.remove(sessionId);
         }
+
+        var respParams = response.path("params");
+        boolean cancel = respParams.path("cancel").asBoolean(false);
+        String answer = respParams.path("answer").asText("");
+        boolean wasFreeform = respParams.path("wasFreeform").asBoolean(true);
 
         var result = objectMapper.createObjectNode();
         result.put("requestId", requestId);
-        if (resolution.cancel()) {
+        if (cancel) {
             result.put("cancel", true);
             result.put("answer", "");
             result.put("wasFreeform", true);
         } else {
-            result.put("answer", resolution.answer() != null ? resolution.answer() : "");
-            result.put("wasFreeform", resolution.wasFreeform());
+            result.put("answer", answer);
+            result.put("wasFreeform", wasFreeform);
         }
         return result;
     }
@@ -2134,13 +2090,19 @@ public final class StreamingAgentHandler {
         sessionLastPremiumUsed.remove(sessionId);
         // Release any sidecar-side RequestHandler thread still blocked on
         // the CompletableFuture for a pending question so it doesn't wedge
-        // the sidecar during teardown.
+        // the sidecar during teardown. Completes with a synthetic
+        // user_input.response shape matching what the monitor would have
+        // routed — cancel=true with no answer.
         var stalePending = pendingUserInput.remove(sessionId);
-        if (stalePending != null) {
-            stalePending.future().complete(
-                    new UserInputAnswer(
-                            "(session ended before the clarification was answered)",
-                            true, true));
+        if (stalePending != null && !stalePending.future().isDone()) {
+            var synthetic = objectMapper.createObjectNode();
+            synthetic.put("method", "user_input.response");
+            var p = synthetic.putObject("params");
+            p.put("requestId", stalePending.requestId());
+            p.put("cancel", true);
+            p.put("answer", "");
+            p.put("wasFreeform", true);
+            stalePending.future().complete(synthetic);
         }
         var client = sessionSidecars.remove(sessionId);
         if (client == null) return;
@@ -3752,6 +3714,7 @@ public final class StreamingAgentHandler {
         private final SocketChannel channel;
         private final StringBuilder lineBuilder;
         private final ConcurrentHashMap<String, CompletableFuture<JsonNode>> pendingPermissions = new ConcurrentHashMap<>();
+        private final ConcurrentHashMap<String, CompletableFuture<JsonNode>> pendingUserInputs = new ConcurrentHashMap<>();
         private final BlockingQueue<JsonNode> unmatchedResponses = new LinkedBlockingQueue<>();
         private final Object permissionLifecycleLock = new Object();
         private volatile boolean stopped = false;
@@ -3804,6 +3767,41 @@ public final class StreamingAgentHandler {
             CompletableFuture<JsonNode> future;
             synchronized (permissionLifecycleLock) {
                 future = pendingPermissions.remove(requestId);
+            }
+            if (future != null && !future.isDone()) {
+                future.cancel(false);
+            }
+        }
+
+        /**
+         * Phase 3 (#5). Registers a pending {@code user_input.requested}
+         * keyed by requestId. Returns a future completed when the matching
+         * {@code user_input.response} notification arrives on this
+         * connection's monitor thread.
+         */
+        CompletableFuture<JsonNode> registerUserInputRequest(String requestId) {
+            Objects.requireNonNull(requestId, "requestId");
+            var future = new CompletableFuture<JsonNode>();
+            synchronized (permissionLifecycleLock) {
+                if (stopped) {
+                    future.cancel(false);
+                    return future;
+                }
+                var previous = pendingUserInputs.putIfAbsent(requestId, future);
+                if (previous != null) {
+                    future.cancel(false);
+                    throw new IllegalStateException("Duplicate user_input requestId: " + requestId);
+                }
+            }
+            return future;
+        }
+
+        /** Cancels + unregisters a pending user_input future (e.g. on session teardown). */
+        void unregisterUserInputRequest(String requestId) {
+            Objects.requireNonNull(requestId, "requestId");
+            CompletableFuture<JsonNode> future;
+            synchronized (permissionLifecycleLock) {
+                future = pendingUserInputs.remove(requestId);
             }
             if (future != null && !future.isDone()) {
                 future.cancel(false);
@@ -3910,6 +3908,21 @@ public final class StreamingAgentHandler {
                                         }
                                     } else {
                                         log.warn("Cancel monitor: permission.response missing requestId, dropping message");
+                                    }
+                                } else if ("user_input.response".equals(method)) {
+                                    log.debug("Cancel monitor: routing user_input.response");
+                                    var respParams = message.get("params");
+                                    var rid = respParams != null && respParams.has("requestId")
+                                            ? respParams.get("requestId").asText() : null;
+                                    if (rid != null) {
+                                        var future = pendingUserInputs.remove(rid);
+                                        if (future != null) {
+                                            future.complete(message);
+                                        } else {
+                                            log.warn("Cancel monitor: no pending user_input for requestId={}, dropping", rid);
+                                        }
+                                    } else {
+                                        log.warn("Cancel monitor: user_input.response missing requestId, dropping message");
                                     }
                                 } else if ("resume.response".equals(method)) {
                                     log.debug("Cancel monitor: routing resume.response to fallback");

--- a/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/StreamingAgentHandler.java
+++ b/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/StreamingAgentHandler.java
@@ -3829,10 +3829,28 @@ public final class StreamingAgentHandler {
          */
         void stopMonitor() {
             stopped = true;
-            // Cancel all pending permission futures so waiting threads unblock
+            // Cancel all pending permission + user_input futures so waiting
+            // threads unblock. A client disconnect landing here while a
+            // Copilot clarification is pending (issue #5) would otherwise
+            // wedge the sidecar-facing request handler indefinitely, which
+            // in turn pins the active sendAndWait until session teardown.
             synchronized (permissionLifecycleLock) {
                 pendingPermissions.forEach((_, future) -> future.cancel(false));
                 pendingPermissions.clear();
+                pendingUserInputs.forEach((_, future) -> {
+                    // Complete with a synthetic cancel notification so the
+                    // handler returns a deterministic cancel-shaped result
+                    // to the sidecar rather than propagating a cancellation
+                    // exception back through the RPC pipeline.
+                    var msg = objectMapper.createObjectNode();
+                    msg.put("method", "user_input.response");
+                    var p = msg.putObject("params");
+                    p.put("cancel", true);
+                    p.put("answer", "");
+                    p.put("wasFreeform", true);
+                    future.complete(msg);
+                });
+                pendingUserInputs.clear();
             }
             var sel = selector;
             if (sel != null) {

--- a/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/StreamingAgentHandler.java
+++ b/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/StreamingAgentHandler.java
@@ -192,6 +192,30 @@ public final class StreamingAgentHandler {
     // snapshot is not guaranteed to be pre-billing).
     private final ConcurrentHashMap<String, Long> sessionLastPremiumUsed =
             new ConcurrentHashMap<>();
+    // Phase 3 (#5): per-session pending user_input.requested. Only one is
+    // tracked at a time — the SDK agent blocks inside a single sendAndWait
+    // while awaiting an answer, so there can be at most one outstanding
+    // question per session.
+    private final ConcurrentHashMap<String, PendingUserInput> pendingUserInput =
+            new ConcurrentHashMap<>();
+
+    /**
+     * Snapshot of a pending {@code user_input.request} the SDK agent is
+     * blocked on inside a {@code sendAndWait}. {@link #future} is completed
+     * by {@code agent.respondToUserInput} (with an answer) or by
+     * timeout / session teardown (with a cancel).
+     */
+    record PendingUserInput(
+            String sessionId,
+            String requestId,
+            String question,
+            List<String> choices,
+            boolean allowFreeform,
+            CompletableFuture<UserInputAnswer> future,
+            long createdAtMs) {}
+
+    /** The user's resolution of a pending {@code user_input.requested}. */
+    record UserInputAnswer(String answer, boolean wasFreeform, boolean cancel) {}
     private volatile String copilotRuntime = "chat";
     private volatile String copilotGithubToken;
     private volatile Path copilotSidecarDir;
@@ -224,6 +248,52 @@ public final class StreamingAgentHandler {
      */
     public void register(RequestRouter router) {
         router.registerStreaming("agent.prompt", this::handlePrompt);
+        router.register("agent.respondToUserInput", this::handleRespondToUserInput);
+    }
+
+    /**
+     * Phase 3 (#5). Resolves a pending {@code user_input.requested} for the
+     * given session so the SDK agent (waiting inside a currently-executing
+     * {@code sendAndWait}) can continue without incurring a new premium
+     * request. Returns quickly — the actual agent work happens in-session.
+     *
+     * <p>Params:
+     * <ul>
+     *   <li>{@code sessionId} — required</li>
+     *   <li>{@code requestId} — required, must match the pending request</li>
+     *   <li>{@code answer} — free-form or choice string; required unless
+     *       {@code cancel} is true</li>
+     *   <li>{@code wasFreeform} — optional, defaults to true</li>
+     *   <li>{@code cancel} — optional; true discards the pending
+     *       question (the SDK agent receives a short decline message so
+     *       it can wrap up the current turn). The caller is responsible
+     *       for any subsequent {@code agent.prompt}.</li>
+     * </ul>
+     */
+    private Object handleRespondToUserInput(JsonNode params) {
+        String sessionId = requireString(params, "sessionId");
+        String requestId = requireString(params, "requestId");
+        boolean cancel = params.path("cancel").asBoolean(false);
+        String answer = params.path("answer").asText("");
+        boolean wasFreeform = params.path("wasFreeform").asBoolean(true);
+
+        var pending = pendingUserInput.get(sessionId);
+        if (pending == null) {
+            throw new IllegalStateException("No pending user_input for session " + sessionId);
+        }
+        if (!pending.requestId().equals(requestId)) {
+            throw new IllegalStateException(
+                    "Stale requestId " + requestId + " for session " + sessionId
+                            + "; current pending requestId is " + pending.requestId());
+        }
+        pendingUserInput.remove(sessionId);
+        pending.future().complete(new UserInputAnswer(answer, wasFreeform, cancel));
+
+        var result = objectMapper.createObjectNode();
+        result.put("sessionId", sessionId);
+        result.put("requestId", requestId);
+        result.put("resolved", cancel ? "cancelled" : "answered");
+        return result;
     }
 
     private Object handlePrompt(JsonNode params, StreamContext context) throws Exception {
@@ -1947,6 +2017,89 @@ public final class StreamingAgentHandler {
         }
     }
 
+    /**
+     * Phase 3 (#5). The sidecar's {@code onUserInputRequest} callback
+     * arrives here as a {@code user_input.request} RPC. We register the
+     * pending question, emit a {@code user_input.requested} notification
+     * to the TUI, and block the sidecar-side RequestHandler thread on a
+     * {@link CompletableFuture} until {@code agent.respondToUserInput}
+     * resolves it (or timeout / cancellation clears it).
+     *
+     * <p>The whole exchange stays inside the current {@code sendAndWait}
+     * — no new turn is issued — so answering a clarifying question costs
+     * 0 premium requests. The user's follow-up becomes chargeable only
+     * if the TUI routes it to a new {@code agent.prompt} instead.
+     */
+    private JsonNode handleSidecarUserInputRequest(JsonNode params,
+                                                    CancelAwareStreamContext cancelContext,
+                                                    String sessionId) throws Exception {
+        String requestId = params.path("requestId").asText(null);
+        if (requestId == null || requestId.isBlank()) {
+            requestId = UUID.randomUUID().toString();
+        }
+        String question = params.path("question").asText("");
+        boolean allowFreeform = params.path("allowFreeform").asBoolean(true);
+        List<String> choices = new ArrayList<>();
+        if (params.has("choices") && params.get("choices").isArray()) {
+            params.get("choices").forEach(c -> {
+                if (c != null && !c.isNull()) choices.add(c.asText());
+            });
+        }
+
+        var future = new CompletableFuture<UserInputAnswer>();
+        var existing = pendingUserInput.putIfAbsent(sessionId,
+                new PendingUserInput(sessionId, requestId, question, choices,
+                        allowFreeform, future, System.currentTimeMillis()));
+        if (existing != null) {
+            // Should not happen — the SDK serializes questions — but surface
+            // it rather than corrupting state by silently overwriting.
+            throw new IllegalStateException(
+                    "user_input.request collided with an existing pending question for session " + sessionId);
+        }
+
+        try {
+            var notif = objectMapper.createObjectNode();
+            notif.put("sessionId", sessionId);
+            notif.put("requestId", requestId);
+            notif.put("question", question);
+            notif.put("allowFreeform", allowFreeform);
+            var choicesNode = notif.putArray("choices");
+            choices.forEach(choicesNode::add);
+            cancelContext.sendNotification("user_input.requested", notif);
+        } catch (IOException e) {
+            pendingUserInput.remove(sessionId);
+            throw new RuntimeException("Failed to emit user_input.requested: " + e.getMessage(), e);
+        }
+
+        UserInputAnswer resolution;
+        try {
+            // Block until the TUI (or a timeout) resolves the future.
+            // The request-dispatch executor is cached / unbounded so
+            // sitting on this thread is acceptable. Phase 3 c5 will add
+            // a configurable timeout here.
+            resolution = future.get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            pendingUserInput.remove(sessionId);
+            throw new IOException("Interrupted while awaiting user_input answer", e);
+        } catch (ExecutionException e) {
+            pendingUserInput.remove(sessionId);
+            throw new IOException("user_input future failed: " + e.getMessage(), e);
+        }
+
+        var result = objectMapper.createObjectNode();
+        result.put("requestId", requestId);
+        if (resolution.cancel()) {
+            result.put("cancel", true);
+            result.put("answer", "");
+            result.put("wasFreeform", true);
+        } else {
+            result.put("answer", resolution.answer() != null ? resolution.answer() : "");
+            result.put("wasFreeform", resolution.wasFreeform());
+        }
+        return result;
+    }
+
     private void emitToolUse(CancelAwareStreamContext ctx, String id, String name, String inputJson) {
         try {
             var p = objectMapper.createObjectNode();
@@ -1979,6 +2132,16 @@ public final class StreamingAgentHandler {
         sessionLastModel.remove(sessionId);
         sessionLastToolSignature.remove(sessionId);
         sessionLastPremiumUsed.remove(sessionId);
+        // Release any sidecar-side RequestHandler thread still blocked on
+        // the CompletableFuture for a pending question so it doesn't wedge
+        // the sidecar during teardown.
+        var stalePending = pendingUserInput.remove(sessionId);
+        if (stalePending != null) {
+            stalePending.future().complete(
+                    new UserInputAnswer(
+                            "(session ended before the clarification was answered)",
+                            true, true));
+        }
         var client = sessionSidecars.remove(sessionId);
         if (client == null) return;
         try {
@@ -2115,6 +2278,9 @@ public final class StreamingAgentHandler {
         client.setRequestHandler((method, params) -> {
             if ("tool.invoke".equals(method)) {
                 return handleCopilotToolInvoke(params, permissionAwareRegistry, cancelContext, sessionId);
+            }
+            if ("user_input.request".equals(method)) {
+                return handleSidecarUserInputRequest(params, cancelContext, sessionId);
             }
             log.warn("Unhandled sidecar RPC: {}", method);
             throw new IllegalArgumentException("unsupported method: " + method);

--- a/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/StreamingAgentHandler.java
+++ b/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/StreamingAgentHandler.java
@@ -114,6 +114,9 @@ public final class StreamingAgentHandler {
 
     private static final Logger log = LoggerFactory.getLogger(StreamingAgentHandler.class);
 
+    /** Phase 3 (#5) c5: daemon side timeout mirroring the TUI's 5-minute clarification deadline. */
+    private static final long COPILOT_USER_INPUT_WAIT_TIMEOUT_SECONDS = 5 * 60 + 30;
+
     /** Permission level assignments for known tools. */
     private static final Map<String, PermissionLevel> TOOL_PERMISSION_LEVELS = Map.ofEntries(
             Map.entry("read_file", PermissionLevel.READ),
@@ -2024,8 +2027,27 @@ public final class StreamingAgentHandler {
             // Block until the TUI's user_input.response notification is
             // routed to us (or session teardown cancels the future).
             // Request-dispatch executor is cached, so parking this thread
-            // is acceptable. Phase 3 c5 adds a configurable timeout.
-            response = metaFuture.get();
+            // is acceptable.
+            //
+            // Phase 3 c5: bounded wait so a TUI that crashes or disconnects
+            // silently — i.e. the cancelContext is still alive but never
+            // gets a user_input.response — doesn't pin this thread forever.
+            // Matches CLIENT_USER_INPUT_WAIT_TIMEOUT_MS on the TUI side (5
+            // minutes); +30s slack so the client's auto-cancel usually wins
+            // the race and we see a clean cancel rather than a synthetic
+            // timeout here.
+            response = metaFuture.get(COPILOT_USER_INPUT_WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        } catch (TimeoutException e) {
+            log.warn("user_input.request timed out for session {} requestId {} after {}s",
+                    sessionId, requestId, COPILOT_USER_INPUT_WAIT_TIMEOUT_SECONDS);
+            pendingUserInput.remove(sessionId);
+            cancelContext.unregisterUserInputRequest(requestId);
+            var synthetic = objectMapper.createObjectNode();
+            synthetic.put("requestId", requestId);
+            synthetic.put("cancel", true);
+            synthetic.put("answer", "");
+            synthetic.put("wasFreeform", true);
+            return synthetic;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             pendingUserInput.remove(sessionId);

--- a/ace-copilot-llm/src/test/java/dev/acecopilot/llm/copilot/CopilotAcpClientUserInputSmokeTest.java
+++ b/ace-copilot-llm/src/test/java/dev/acecopilot/llm/copilot/CopilotAcpClientUserInputSmokeTest.java
@@ -1,0 +1,113 @@
+package dev.acecopilot.llm.copilot;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Phase 3 (#5) smoke test: verifies the sidecar → daemon
+ * {@code user_input.request} round-trip via the mock sidecar
+ * {@code mock-sidecar-user-input.mjs}. No real SDK involved.
+ *
+ * <p>Exercises:
+ * <ul>
+ *   <li>sidecar initiates {@code user_input.request} during sendAndWait</li>
+ *   <li>Java {@link CopilotAcpClient.RequestHandler} receives the RPC
+ *       with the expected params shape</li>
+ *   <li>handler's response flows back and is threaded into the final
+ *       assistant content — proving the Promise seen by the SDK
+ *       actually resolves with our answer</li>
+ * </ul>
+ */
+@EnabledIf("nodeAvailable")
+class CopilotAcpClientUserInputSmokeTest {
+
+    static boolean nodeAvailable() {
+        try {
+            var p = new ProcessBuilder("node", "--version").redirectErrorStream(true).start();
+            return p.waitFor() == 0;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @Test
+    void sidecarUserInputRequestRoundtripsThroughRequestHandler(@TempDir Path dir) throws IOException {
+        copyResource("/copilot/mock-sidecar-user-input.mjs", dir.resolve("sidecar.mjs"));
+        var mapper = new ObjectMapper();
+
+        var captured = new AtomicReference<JsonNode>();
+        CopilotAcpClient.SendResult result;
+        try (var client = new CopilotAcpClient(dir, null)) {
+            client.setRequestHandler((method, params) -> {
+                if ("user_input.request".equals(method)) {
+                    captured.set(params);
+                    var answer = mapper.createObjectNode();
+                    answer.put("requestId", params.path("requestId").asText());
+                    answer.put("answer", "red");
+                    answer.put("wasFreeform", false);
+                    return answer;
+                }
+                throw new IllegalArgumentException("unexpected method: " + method);
+            });
+            result = client.sendAndWait("test-model", "pick a color", List.of(), null);
+        }
+
+        var params = captured.get();
+        assertThat(params).as("sidecar issued user_input.request back to Java").isNotNull();
+        assertThat(params.path("requestId").asText()).isEqualTo("mock-rid-42");
+        assertThat(params.path("question").asText()).isEqualTo("Which color?");
+        assertThat(params.path("allowFreeform").asBoolean()).isTrue();
+        var choices = params.get("choices");
+        assertThat(choices).isNotNull();
+        assertThat(choices.isArray()).isTrue();
+        assertThat(choices.size()).isEqualTo(2);
+        assertThat(choices.get(0).asText()).isEqualTo("red");
+
+        assertThat(result.content())
+                .as("handler's answer was delivered back to the SDK and included in the assistant content")
+                .isEqualTo("agent received: red");
+        assertThat(result.stopReason()).isEqualTo("COMPLETE");
+    }
+
+    @Test
+    void handlerReturningCancelResolvesToAgentWithCancelFlag(@TempDir Path dir) throws IOException {
+        copyResource("/copilot/mock-sidecar-user-input.mjs", dir.resolve("sidecar.mjs"));
+        var mapper = new ObjectMapper();
+        CopilotAcpClient.SendResult result;
+        try (var client = new CopilotAcpClient(dir, null)) {
+            client.setRequestHandler((method, params) -> {
+                if ("user_input.request".equals(method)) {
+                    var answer = mapper.createObjectNode();
+                    answer.put("requestId", params.path("requestId").asText());
+                    answer.put("cancel", true);
+                    return answer;
+                }
+                throw new IllegalArgumentException("unexpected method: " + method);
+            });
+            result = client.sendAndWait("test-model", "pick a color", List.of(), null);
+        }
+        assertThat(result.content())
+                .as("/new escape hatch: handler returns cancel:true, SDK sees a decline payload")
+                .isEqualTo("agent received: (cancelled)");
+    }
+
+    private static void copyResource(String cp, Path dest) throws IOException {
+        try (InputStream in = CopilotAcpClientUserInputSmokeTest.class.getResourceAsStream(cp)) {
+            if (in == null) throw new IOException("classpath resource missing: " + cp);
+            Files.copy(in, dest, StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+}

--- a/ace-copilot-llm/src/test/resources/copilot/mock-sidecar-user-input.mjs
+++ b/ace-copilot-llm/src/test/resources/copilot/mock-sidecar-user-input.mjs
@@ -1,0 +1,90 @@
+// Phase 3 mock sidecar (#5).
+//
+// During session.sendAndWait, this mock issues a user_input.request RPC
+// back to the daemon (simulating the SDK agent firing ask_user) and
+// threads the daemon's resolution into the final assistant content so
+// the test can assert round-trip shape. Used by
+// CopilotAcpClientUserInputSmokeTest.
+
+let nextOutId = 1;
+const pendingOut = new Map();
+
+function writeMessage(obj) {
+  const body = JSON.stringify(obj);
+  const buf = Buffer.from(body, "utf8");
+  process.stdout.write(`Content-Length: ${buf.length}\r\n\r\n`);
+  process.stdout.write(buf);
+}
+
+function request(method, params) {
+  return new Promise((resolve, reject) => {
+    const id = nextOutId++;
+    pendingOut.set(id, { resolve, reject });
+    writeMessage({ jsonrpc: "2.0", id, method, params });
+  });
+}
+
+let buffer = Buffer.alloc(0);
+process.stdin.on("data", (chunk) => {
+  buffer = Buffer.concat([buffer, chunk]);
+  while (true) {
+    const sep = buffer.indexOf("\r\n\r\n");
+    if (sep < 0) return;
+    const m = /Content-Length:\s*(\d+)/i.exec(buffer.slice(0, sep).toString("utf8"));
+    if (!m) process.exit(2);
+    const len = parseInt(m[1], 10);
+    const bodyStart = sep + 4;
+    if (buffer.length < bodyStart + len) return;
+    const body = buffer.slice(bodyStart, bodyStart + len).toString("utf8");
+    buffer = buffer.slice(bodyStart + len);
+    const msg = JSON.parse(body);
+    if (msg.id !== undefined && (msg.result !== undefined || msg.error !== undefined) && msg.method === undefined) {
+      const p = pendingOut.get(msg.id);
+      if (p) {
+        pendingOut.delete(msg.id);
+        if (msg.error) p.reject(new Error(msg.error.message ?? "err"));
+        else p.resolve(msg.result);
+      }
+      continue;
+    }
+    handle(msg);
+  }
+});
+
+async function handle(msg) {
+  const { id, method, params } = msg;
+  try {
+    let result;
+    switch (method) {
+      case "initialize":
+        result = { protocolVersion: "0.1" };
+        break;
+      case "session.sendAndWait": {
+        const r = await request("user_input.request", {
+          requestId: "mock-rid-42",
+          question: "Which color?",
+          choices: ["red", "blue"],
+          allowFreeform: true,
+        });
+        const answer = r?.cancel ? "(cancelled)" : (r?.answer ?? "");
+        const wasFreeform = r?.wasFreeform === true ? " freeform" : "";
+        result = {
+          content: `agent received: ${answer}${wasFreeform}`,
+          stopReason: "COMPLETE",
+        };
+        break;
+      }
+      case "shutdown":
+        writeMessage({ jsonrpc: "2.0", id, result: null });
+        process.exit(0);
+        return;
+      default:
+        throw new Error("unknown method: " + method);
+    }
+    if (id !== undefined) writeMessage({ jsonrpc: "2.0", id, result });
+  } catch (e) {
+    if (id !== undefined) {
+      writeMessage({ jsonrpc: "2.0", id, error: { code: -32000, message: String(e?.message ?? e) } });
+    }
+  }
+}

--- a/ace-copilot-sidecar/sidecar.mjs
+++ b/ace-copilot-sidecar/sidecar.mjs
@@ -25,6 +25,15 @@
 //                        premiumUsed, premiumLimit }
 //   - Requests from sidecar → daemon (Phase 2, issue #4):
 //       tool.invoke         { name, arguments } → { content, isError? }
+//   - Requests from sidecar → daemon (Phase 3, issue #5):
+//       user_input.request  { requestId, question, choices?, allowFreeform? }
+//                            → { answer: string, wasFreeform: boolean, cancel?: boolean }
+//                            — fired when the SDK agent asks a clarifying
+//                              question. The daemon blocks on this RPC while
+//                              it awaits the user's response (through the TUI
+//                              agent.respondToUserInput path). If the daemon
+//                              returns { cancel: true } the sidecar responds
+//                              to the SDK with a decline-shaped answer.
 //   - Additional notifications (Pre-Phase 3, issue #12):
 //       session/elicitation_declined
 //                            { mode, message, elicitationSource, url }
@@ -195,6 +204,40 @@ async function ensureSession(model, toolDefs) {
     const sessionOpts = {
       model,
       streaming: true,
+      // Phase 3 (#5): the SDK agent can ask a clarifying question
+      // (`ask_user` tool under the hood) — surface it to the daemon via
+      // the long-running user_input.request RPC. The Promise returned
+      // here only resolves when the daemon has the user's answer in
+      // hand, which is what keeps the whole exchange inside a single
+      // billable sendAndWait. If the daemon decides to cancel the
+      // pending question (e.g. the user typed /new), we return a short
+      // decline message so the SDK agent wraps up gracefully.
+      onUserInputRequest: async (req, _invocation) => {
+        try {
+          const r = await request("user_input.request", {
+            requestId: req?.requestId ?? null,
+            question: req?.question ?? "",
+            choices: Array.isArray(req?.choices) ? req.choices : [],
+            allowFreeform: req?.allowFreeform !== false,
+          });
+          if (r?.cancel === true) {
+            return {
+              answer: "(user cancelled this clarification and started a new task)",
+              wasFreeform: true,
+            };
+          }
+          return {
+            answer: typeof r?.answer === "string" ? r.answer : "",
+            wasFreeform: r?.wasFreeform !== false,
+          };
+        } catch (e) {
+          log("user_input bridge failed:", e?.message ?? e);
+          return {
+            answer: "(clarification could not be delivered — please proceed with best-effort assumptions)",
+            wasFreeform: true,
+          };
+        }
+      },
       onPermissionRequest: async (req) => {
         // Custom tools are gated by the daemon's PermissionAwareTool when
         // tool.invoke executes — approve here so the SDK calls our handler

--- a/docs/copilot-session-runtime.md
+++ b/docs/copilot-session-runtime.md
@@ -63,11 +63,57 @@ but is a no-op; daemon logs an info line if it is still present.
 - Tool activity via `stream.tool_use` / `stream.tool_completed` —
   parity with the chat path's turn-summary rendering.
 
+## Clarification routing (Phase 3, #5)
+
+When the SDK agent fires `ask_user`, the sidecar round-trips the
+question through the daemon to the TUI. Answering costs **0**
+additional premium requests — the exchange stays inside the current
+`sendAndWait`. The TUI shows a short `[waiting for clarification]`
+line, a dedicated answer prompt, and whether the clarification was
+answered or cancelled.
+
+Two commands the user can type at the clarification prompt:
+
+- **plain text** — treated as the answer. If the text matches one of
+  the SDK's offered `choices` (case-insensitive), it's sent back with
+  `wasFreeform: false`; otherwise as free-form.
+- **`/new <prompt>`** — cancels the pending clarification (sidecar
+  returns `cancel: true` to the SDK, agent wraps up the current turn),
+  then queues `<prompt>` as the next task. A bare `/new` cancels
+  without queuing anything and returns the session to ready.
+
+Timeout: if the user does not answer within **5 minutes**, the TUI
+auto-cancels and the agent wraps up. Daemon-side has a matching
++30-second deadline as a safety net — either side firing first yields
+the same shape (cancel response) so no state is ever wedged.
+
+### Policy: mix A→B fallback (locked)
+
+The `@github/copilot-sdk` does not expose an externally-callable
+`respondToUserInput` — the only way to resolve an `ask_user` is from
+inside its `onUserInputRequest` callback (see
+`experiments/copilot-session-probe/probe-fake-pending.mjs`). This
+means 0-premium follow-ups are only possible when the agent is
+currently pending on `ask_user`. The runtime therefore uses a two-path
+policy:
+
+- **A (preferred)**: agent stays in `ask_user` between turns →
+  user's typed answer resolves the callback → 0 premium.
+- **B (fallback)**: agent finished `sendAndWait` without pending →
+  typed input becomes a new `sendAndWait` on the same SDK session
+  → context preserved but +1 premium.
+
+Hit rate of A depends on prompt steering (agent discipline in closing
+each turn with `ask_user`), tracked in Phase 3 c4. There is no
+additional code-level trick that achieves 0-premium follow-up —
+pretending a pending state exists would silently desync from SDK
+reality.
+
 ## Intentionally deferred
 
 | Area | Status | Tracked in |
 | --- | --- | --- |
-| `respondToUserInput` routing (follow-up messages cost 0 premium) | Not implemented — each follow-up is a new billable `sendAndWait` | #5 |
+| Prompt steering to maximise A hit rate | Agents may end turns without `ask_user`, falling back to B | #5 c4 |
 | Structured-form elicitation (MCP etc.) | Auto-declined + yellow warning in TUI | #5 |
 | Incremental mid-execution output for long-running tools (`bash`, etc.) | One `stream.tool_completed` payload at the end, not streamed | #5 |
 | TaskPlanner consolidated inside the session | Still runs via separate LLM calls | #6 |

--- a/experiments/copilot-session-probe/probe-fake-pending.mjs
+++ b/experiments/copilot-session-probe/probe-fake-pending.mjs
@@ -1,0 +1,158 @@
+// Probe: what happens if we try to "continue" after sendAndWait has already
+// resolved and there is no real pending user_input request?
+//
+// Goal:
+//   1. Run a prompt that should complete naturally without ask_user
+//   2. Verify whether the SDK exposes any valid after-the-fact user-input
+//      continuation surface once the turn has gone idle
+//   3. Show the practical fallback: another sendAndWait in the same session
+//
+// Run:
+//   cd experiments/copilot-session-probe
+//   node probe-fake-pending.mjs
+//   MODEL=claude-haiku-4.5 node probe-fake-pending.mjs
+//   GH_ACCOUNT=xinhua-gu_acncp node probe-fake-pending.mjs
+
+import { CopilotClient, approveAll } from "@github/copilot-sdk";
+import { execFileSync } from "node:child_process";
+
+const MODEL = process.env.MODEL ?? "claude-haiku-4.5";
+const GH_ACCOUNT = process.env.GH_ACCOUNT ?? null;
+
+function resolveAccountToken(account) {
+  const out = execFileSync("gh", ["auth", "token", "--user", account], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const token = out.trim();
+  if (!token) throw new Error(`gh auth token --user ${account} returned empty`);
+  return token;
+}
+
+const NATURAL_PROMPT = `
+Answer the following in exactly one short paragraph and then STOP.
+Do not ask any clarifying questions.
+Do not use ask_user.
+
+Question: what is the purpose of a README file in a software project?
+`.trim();
+
+const FOLLOW_UP_PROMPT = `
+Continue the same topic in one short paragraph: what should a good README include?
+Do not ask any clarifying questions.
+`.trim();
+
+async function main() {
+  const started = Date.now();
+  const clientOpts = {};
+  if (GH_ACCOUNT) {
+    clientOpts.githubToken = resolveAccountToken(GH_ACCOUNT);
+    clientOpts.useLoggedInUser = false;
+    console.log(`[probe] using gh account: ${GH_ACCOUNT} (token resolved, gh active account unchanged)`);
+  }
+
+  const client = new CopilotClient(clientOpts);
+  console.log(`[probe] client created (model=${MODEL})`);
+
+  let userInputRequests = 0;
+  const timeline = [];
+
+  const session = await client.createSession({
+    model: MODEL,
+    streaming: true,
+    onPermissionRequest: approveAll,
+    onUserInputRequest: async (req) => {
+      userInputRequests++;
+      timeline.push({
+        t: Date.now() - started,
+        event: "unexpected.user_input.requested",
+        question: req?.question ?? "",
+      });
+      console.log("\n[probe] UNEXPECTED ask_user fired:");
+      console.log(`        requestId: ${req?.requestId ?? "(none)"}`);
+      console.log(`        question:  ${req?.question ?? "(none)"}`);
+      return { answer: "No clarification should have been needed here.", wasFreeform: true };
+    },
+  });
+
+  session.on((event) => {
+    if (event?.type === "assistant.message") {
+      timeline.push({ t: Date.now() - started, event: "assistant.message" });
+    } else if (event?.type === "session.idle") {
+      timeline.push({ t: Date.now() - started, event: "session.idle" });
+    }
+  });
+
+  console.log("\n[probe] turn #1: prompt that should finish naturally (no ask_user)\n");
+  const first = await session.sendAndWait({ prompt: NATURAL_PROMPT });
+  console.log("\n[probe] turn #1 resolved");
+  console.log(`  content?   ${first?.data?.content ? "yes" : "no"}`);
+  console.log(`  stopReason ${first?.data?.stopReason ?? "(unknown)"}`);
+  console.log(`  ask_user events seen: ${userInputRequests}`);
+
+  const publicKeys = Object.getOwnPropertyNames(Object.getPrototypeOf(session))
+    .filter((k) => !k.startsWith("_"))
+    .sort();
+  console.log("\n[probe] public session methods:");
+  console.log(" ", publicKeys.join(", "));
+  console.log(`[probe] typeof session.respondToUserInput = ${typeof session.respondToUserInput}`);
+
+  const rpcKeys = session.rpc ? Object.keys(session.rpc).sort() : [];
+  console.log(`[probe] top-level session.rpc keys: ${rpcKeys.join(", ")}`);
+  const userInputRpcKeys = rpcKeys.filter((k) => k.toLowerCase().includes("user"));
+  console.log(`[probe] session.rpc keys mentioning 'user': ${userInputRpcKeys.join(", ") || "(none)"}`);
+
+  let fakeContinuationOutcome = "not-attempted";
+  let fakeContinuationError = "";
+  if (typeof session.respondToUserInput === "function") {
+    try {
+      console.log("[probe] attempting session.respondToUserInput with fake requestId...");
+      const r = await session.respondToUserInput({
+        requestId: "fake-after-resolve-request-id",
+        response: "Pretend this is an answer after the turn already ended.",
+      });
+      fakeContinuationOutcome = "resolved";
+      console.log("[probe] fake continuation unexpectedly resolved:", r);
+    } catch (e) {
+      fakeContinuationOutcome = "threw";
+      fakeContinuationError = e?.message ?? String(e);
+      console.log(`[probe] fake continuation threw: ${fakeContinuationError}`);
+    }
+  } else {
+    fakeContinuationOutcome = "api-missing";
+    console.log("[probe] no public session.respondToUserInput API exists after the turn resolved.");
+  }
+
+  console.log("\n[probe] turn #2: explicit second sendAndWait in the SAME session\n");
+  const second = await session.sendAndWait({ prompt: FOLLOW_UP_PROMPT });
+  console.log("\n[probe] turn #2 resolved");
+  console.log(`  content?   ${second?.data?.content ? "yes" : "no"}`);
+  console.log(`  stopReason ${second?.data?.stopReason ?? "(unknown)"}`);
+
+  console.log("\n[probe] ---------- SUMMARY ----------");
+  console.log(`  turn #1 ask_user count:      ${userInputRequests}`);
+  console.log(`  fake continuation outcome:   ${fakeContinuationOutcome}`);
+  if (fakeContinuationError) {
+    console.log(`  fake continuation error:     ${fakeContinuationError}`);
+  }
+  console.log("  observed fallback:           second sendAndWait in same SDK session succeeds");
+  console.log("  interpretation:");
+  console.log("    - If turn #1 ended without ask_user, there was no real pending question.");
+  console.log("    - After that, the SDK surface does not provide a normal post-resolve answer path here.");
+  console.log("    - Continuing is still possible, but as another sendAndWait in the same session.");
+
+  if (timeline.length) {
+    console.log("  timeline:");
+    for (const e of timeline) {
+      const extra = e.question ? ` :: ${e.question.slice(0, 60)}` : "";
+      console.log(`    +${String(e.t).padStart(6)}ms  ${e.event}${extra}`);
+    }
+  }
+
+  await client.stop();
+}
+
+main().catch((err) => {
+  console.error("\n[probe] error:", err?.stack ?? err);
+  process.exit(1);
+});

--- a/experiments/copilot-session-probe/probe-stale-user-input.mjs
+++ b/experiments/copilot-session-probe/probe-stale-user-input.mjs
@@ -1,0 +1,159 @@
+// Probe: what happens when the SDK has already resolved a sendAndWait
+// (no pending user_input) and we then try to "continuation-respond" with
+// a stale, forged, or never-registered requestId?
+//
+// Phase 3 (#5) c3 assumes "sendAndWait returned == no pending clarification
+// on daemon side == safe to treat as normal prompt submission". This probe
+// pins the assumption across all three layers (SDK, sidecar, daemon) so the
+// state machine doesn't silently corrupt if the assumption is wrong.
+//
+// Scenarios exercised in sequence against the same session:
+//   T1 — Baseline:        send a prompt that completes without ask_user.
+//                          Verify a normal JSON-RPC response + usage.copilot.
+//   T2 — Forged requestId: post user_input.response { requestId:"forged" }.
+//                          Daemon has no pending entry → expect warn + drop,
+//                          session stays healthy, no wedge.
+//   T3 — Stale requestId:  remember the sendAndWait's completion, then post
+//                          user_input.response { requestId: T1's response
+//                          apiCallId or similar } — another false match.
+//                          Same expectation.
+//   T4 — Follow-up prompt: immediately send another agent.prompt on the same
+//                          session. Verify it returns normally and premium
+//                          counter advances (rules out "stuck state").
+//
+// Run:
+//   node experiments/copilot-session-probe/probe-stale-user-input.mjs [workspace]
+
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+
+const SOCK = path.join(os.homedir(), ".ace-copilot", "ace-copilot.sock");
+const WORKSPACE = process.argv[2] ?? process.cwd();
+const PROMPT = "What is 2+2? Reply with just the number. Do not use any tools or ask any clarifying questions.";
+
+const client = net.createConnection(SOCK);
+let buf = "";
+let nextId = 1;
+const pending = new Map();
+const notifications = [];
+
+function send(obj) {
+  client.write(JSON.stringify(obj) + "\n");
+}
+
+function request(method, params) {
+  return new Promise((resolve, reject) => {
+    const id = nextId++;
+    pending.set(id, { resolve, reject });
+    send({ jsonrpc: "2.0", id, method, params });
+  });
+}
+
+function notify(method, params) {
+  send({ jsonrpc: "2.0", method, params });
+}
+
+client.on("data", (chunk) => {
+  buf += chunk.toString("utf8");
+  let nl;
+  while ((nl = buf.indexOf("\n")) >= 0) {
+    const line = buf.slice(0, nl);
+    buf = buf.slice(nl + 1);
+    if (!line) continue;
+    let m;
+    try { m = JSON.parse(line); } catch { continue; }
+    if (m.method && !m.id) {
+      notifications.push(m);
+    } else if (m.id !== undefined) {
+      const p = pending.get(m.id);
+      if (p) {
+        pending.delete(m.id);
+        if (m.error) p.reject(new Error(m.error.message ?? JSON.stringify(m.error)));
+        else p.resolve(m.result);
+      }
+    }
+  }
+});
+
+client.on("error", (e) => { console.error("[sock]", e.message); process.exit(1); });
+
+async function main() {
+  const health = await request("health.status", {});
+  console.log(`[probe] daemon model=${health?.model}`);
+
+  const session = await request("session.create", { project: WORKSPACE });
+  const sid = session?.sessionId ?? session?.id;
+  console.log(`[probe] session=${sid}`);
+
+  // T1 — baseline: a prompt that completes without ask_user.
+  console.log("\n=== T1: baseline sendAndWait (no pending expected) ===");
+  const t1Start = Date.now();
+  const t1 = await request("agent.prompt", { sessionId: sid, prompt: PROMPT });
+  const t1Wall = Date.now() - t1Start;
+  console.log(`  stopReason=${t1?.stopReason} wallMs=${t1Wall}`);
+  console.log(`  response head: ${JSON.stringify(t1?.response).slice(0, 80)}`);
+  const t1Cop = t1?.usage?.copilot ?? {};
+  console.log(`  copilot.usageEventCount=${t1Cop.usageEventCount} premiumUsed=${t1Cop.premiumUsedBefore}->${t1Cop.premiumUsedAfter}`);
+  const notifsDuringT1 = notifications.splice(0).filter(n =>
+    n.method === "user_input.requested" || n.method === "stream.warning"
+  );
+  console.log(`  notifications of interest during T1: ${notifsDuringT1.length}`);
+  for (const n of notifsDuringT1) {
+    console.log(`    - ${n.method}: ${JSON.stringify(n.params).slice(0, 120)}`);
+  }
+
+  // T2 — forged requestId after T1's turn ended.
+  console.log("\n=== T2: user_input.response with forged requestId ===");
+  notify("user_input.response", {
+    requestId: "forged-" + Math.random().toString(36).slice(2, 10),
+    answer: "x",
+    wasFreeform: true,
+    cancel: false,
+  });
+  // Small wait for monitor to process; no reply expected.
+  await new Promise((r) => setTimeout(r, 400));
+  console.log("  posted; expecting daemon log 'no pending user_input for requestId=...' and no session effect");
+
+  // T3 — stale but structured-looking requestId.
+  console.log("\n=== T3: user_input.response with a UUID-shaped stale requestId ===");
+  notify("user_input.response", {
+    requestId: "00000000-0000-0000-0000-000000000000",
+    answer: "hi",
+    wasFreeform: true,
+    cancel: false,
+  });
+  await new Promise((r) => setTimeout(r, 400));
+  console.log("  posted; same expectation — dropped, session unaffected");
+
+  // T4 — session still healthy: next agent.prompt works, premium advances.
+  console.log("\n=== T4: follow-up prompt on the same session ===");
+  const t4Start = Date.now();
+  const t4 = await request("agent.prompt", {
+    sessionId: sid,
+    prompt: "What is 3+3? Just the number. No tools, no questions.",
+  });
+  const t4Wall = Date.now() - t4Start;
+  console.log(`  stopReason=${t4?.stopReason} wallMs=${t4Wall}`);
+  console.log(`  response head: ${JSON.stringify(t4?.response).slice(0, 80)}`);
+  const t4Cop = t4?.usage?.copilot ?? {};
+  console.log(`  copilot.premiumUsed=${t4Cop.premiumUsedBefore}->${t4Cop.premiumUsedAfter} sinceLastTurn=${t4Cop.premiumDeltaSinceLastTurn}`);
+
+  // Summary.
+  console.log("\n========= VERDICT =========");
+  const t1Ok = t1?.stopReason === "COMPLETE" && t1Wall < 60_000;
+  const t4Ok = t4?.stopReason === "COMPLETE" && t4Wall < 60_000;
+  console.log(`  T1 completes normally:                    ${t1Ok ? "PASS" : "FAIL"}`);
+  console.log(`  T2/T3 stray user_input.response tolerated: ${t4Ok ? "PASS (session healthy after noise)" : "FAIL"}`);
+  console.log(`  T4 follow-up works + premium advances:    ${t4Ok ? "PASS" : "FAIL"}`);
+  if (!t4Ok) {
+    console.log("  → If T4 fails after T2/T3, stray notifications are corrupting state. Check daemon log.");
+  }
+  console.log("\n  Daemon log grep suggested:");
+  console.log("    tail -100 ~/.ace-copilot/logs/daemon.log | grep -E \"user_input|pending\"");
+
+  await request("session.destroy", { sessionId: sid }).catch(() => {});
+  client.end();
+}
+
+main().catch((e) => { console.error("[probe error]", e); process.exit(1); });


### PR DESCRIPTION
**Phase 3 (#5) — correctness-complete.** Ready to merge once CI is green. Product-facing enhancements (prompt steering, idle-continuation UX, acceptance walkthrough) deliberately held back for a separate follow-up PR so this one stays focused on the state machine and stays reviewable.

## What's done in this PR

### Foundation (c1 + c2)
- Sidecar wires `onUserInputRequest` to a long-running `user_input.request` RPC back to the daemon. The SDK Promise only resolves when the daemon delivers an answer, keeping the exchange inside the current `sendAndWait`.
- Daemon tracks per-session pending state; responses flow in as `user_input.response` notifications on the task connection, routed by `CancelAwareStreamContext`'s monitor — same shape as `permission.response`.

### TUI wiring (c3a + c3b)
- `UserInputBridge` (sibling of `PermissionBridge`): REPL blocks on `requestInput`, submits answer via `submitAnswer`/`cancel`.
- `TaskStreamReader` dispatches through the bridge when registered; auto-cancels with a warning when not (safe fallback).
- `TerminalRepl` creates the bridge, threads it into `TaskManager.submit`, polls it inside `waitForForeground` / `simplePollForeground` and (after reviewer fixes below) at the main-loop head.
- `ForegroundOutputSink.onUserInputRequest` / `onUserInputResolved` render `[waiting for clarification]` and `[answer received]` / `[clarification cancelled]`.
- `/new <prompt>` inside the modal cancels the clarification and queues the next task; `/new` alone returns to idle.

### Reviewer-driven safety fixes
- **P1-a**: TaskStreamReader never handled `user_input.requested` → added auto-cancel fallback so the first clarification doesn't deadlock the session.
- **P1-b**: `CancelAwareStreamContext.stopMonitor` cancels pending permissions but not user_inputs → added symmetric cleanup with synthetic cancel responses.
- **P1 (background tasks)**: user_input was only drained inside `waitForForeground`; a backgrounded task's clarification would sit until timeout. Added `UserInputBridge.setRequestListener` + `interruptPromptForUserInputPopup` + the catch-branch drain symmetric with permissions.
- **P2 (proactive)**: readLine interrupt alone was insufficient for the "arrived just after readLine returned" race. Added top-of-loop `drainUserInputs` mirror of `drainPermissions`.

### Timeouts + cleanup (c5)
- `CLIENT_USER_INPUT_WAIT_TIMEOUT_MS` = 5 min on the CLI; daemon matches with +30s slack so the client cancel typically wins the race.
- Session teardown completes pending futures with synthetic cancel responses.

### Tests + probes (c6)
- `CopilotAcpClientUserInputSmokeTest` pins the sidecar→Java `user_input.request` round-trip via a mock sidecar.
- `probe-stale-user-input.mjs`: confirmed stray `user_input.response` notifications are safely dropped and the session stays healthy.
- `probe-fake-pending.mjs`: **proved the SDK has no externally-callable `respondToUserInput`** — the mix A→B policy is the only viable design, not a choice. Findings committed alongside so future contributors don't chase the 0-premium fallthrough fantasy.

## Deliberately held for a follow-up PR

These items don't affect correctness of the state machine; they're user-facing polish + an end-to-end acceptance script. Putting them in their own PR keeps review surfaces clean:

- **c4 prompt steering** — daemon-side prompt preamble nudging the SDK agent to end turns with `ask_user` when the task isn't finished. Raises A-path hit rate but doesn't change the routing policy.
- **Premium-turn UX on turn summary** — render `copilot: +N premium this turn` so users can see when a plain follow-up became a new billable turn (daemon already emits `premiumDeltaSinceLastTurn`; TUI just needs to display it).
- **Live acceptance walkthrough** — 9-step scenario in `docs/copilot-session-runtime.md` covering long task + `/bg` + clarification + `/new` + idle follow-up + expected deltas.

These commits are already prepared on the `feat/copilot-phase3-enhancements` branch and will be rebased onto main + opened as PR #15 once this one merges. Issue #5 stays open until that follow-up lands.

## Deliberately out of scope

- **Structured-form elicitation** — split to #15 (its own follow-up). Current auto-decline + yellow warning behavior stays on main.
- **Incremental mid-tool-execution output streaming** — tracked in #5's parent scope; deferred.
- **TaskPlanner / SelfImprovementEngine consolidation** — Phase 4, #6.

## Test plan

- [x] `./gradlew build` passes
- [x] New + existing Copilot smoke tests pass
- [x] Manual: clarification flow reached via real Copilot SDK in TUI
- [x] Probes confirm stale / forged `user_input.response` is safely handled
- [ ] Reviewer: run the manual clarification flow with a prompt that forces `ask_user` (e.g. "help me design something, ask me a clarifying question before you start")

🤖 Generated with [Claude Code](https://claude.com/claude-code)