### PR TITLE
feat(copilot): phase 4 B1 — dedicated learning LlmClient for session mode (#6)

### DIFF
--- a/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/AceCopilotConfig.java
+++ b/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/AceCopilotConfig.java
@@ -145,6 +145,22 @@ public final class AceCopilotConfig {
      * and stays on {@code "chat"} (logged at ERROR).
      */
     private boolean copilotRuntimeAcceptUnsandboxed = false;
+    /**
+     * Provider name for the post-turn learning LlmClient (#6 Phase 4 B1).
+     * When set, skill refinement / dynamic skill generation / session skill
+     * packer route their LLM calls through a separate {@link
+     * dev.acecopilot.core.llm.LlmClient} built with this provider instead
+     * of the main one. The point is to keep the learning pipeline running
+     * without eating the user's Copilot premium budget on session mode.
+     *
+     * <p>{@code null} = use the main client (current behaviour).
+     * Setting this to {@code "copilot"} defeats the purpose and is
+     * rejected at load time with a clear error.
+     */
+    private String learningProvider;
+    private String learningBaseUrl;
+    private String learningApiKey;
+    private String learningModel;
     private int maxTokens;
     private int thinkingBudget;
     private int maxTurns;
@@ -717,6 +733,23 @@ public final class AceCopilotConfig {
     /** See {@link #copilotRuntimeAcceptUnsandboxed} — Phase 1 safety gate (#3). */
     public boolean copilotRuntimeAcceptUnsandboxed() {
         return copilotRuntimeAcceptUnsandboxed;
+    }
+
+    /** Phase 4 B1 (#6): dedicated learning-pipeline provider, or {@code null}. */
+    public String learningProvider() {
+        return learningProvider;
+    }
+
+    public String learningBaseUrl() {
+        return learningBaseUrl;
+    }
+
+    public String learningApiKey() {
+        return learningApiKey;
+    }
+
+    public String learningModel() {
+        return learningModel;
     }
 
     /**
@@ -1447,6 +1480,25 @@ public final class AceCopilotConfig {
         if (fileConfig.copilotRuntimeAcceptUnsandboxed != null) {
             this.copilotRuntimeAcceptUnsandboxed = fileConfig.copilotRuntimeAcceptUnsandboxed;
         }
+        if (fileConfig.learningProvider != null && !fileConfig.learningProvider.isBlank()) {
+            String v = fileConfig.learningProvider.trim().toLowerCase();
+            if ("copilot".equals(v)) {
+                log.error("learningProvider=\"copilot\" defeats the purpose of a dedicated learning "
+                        + "provider (#6 Phase 4 B1): the learning pipeline would still consume "
+                        + "Copilot premium. Ignoring and falling back to the main client.");
+            } else {
+                this.learningProvider = v;
+            }
+        }
+        if (fileConfig.learningBaseUrl != null && !fileConfig.learningBaseUrl.isBlank()) {
+            this.learningBaseUrl = fileConfig.learningBaseUrl;
+        }
+        if (fileConfig.learningApiKey != null && !fileConfig.learningApiKey.isBlank()) {
+            this.learningApiKey = fileConfig.learningApiKey;
+        }
+        if (fileConfig.learningModel != null && !fileConfig.learningModel.isBlank()) {
+            this.learningModel = fileConfig.learningModel;
+        }
         if (fileConfig.maxTokens > 0) {
             this.maxTokens = fileConfig.maxTokens;
         }
@@ -1690,6 +1742,10 @@ public final class AceCopilotConfig {
         public String model;
         public String copilotRuntime;
         public Boolean copilotRuntimeAcceptUnsandboxed;
+        public String learningProvider;
+        public String learningBaseUrl;
+        public String learningApiKey;
+        public String learningModel;
         public int maxTokens;
         public int thinkingBudget;
         public int maxTurns;

--- a/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/AceCopilotDaemon.java
+++ b/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/AceCopilotDaemon.java
@@ -236,6 +236,42 @@ public final class AceCopilotDaemon {
         var circuitBreaker = new CircuitBreaker(cbConfig, eventBus);
         LlmClient llmClient = new CircuitBreakerLlmClient(rawLlmClient, circuitBreaker);
 
+        // Phase 4 B1 (#6): if learningProvider is configured, build a second
+        // LlmClient dedicated to the post-turn learning pipeline so it runs
+        // without consuming the user's Copilot premium. Falls back to the
+        // main client when unset (matches pre-B1 behaviour, so existing
+        // installs see no change).
+        final LlmClient learningLlmClient;
+        final String learningModelResolved;
+        if (config.learningProvider() != null && !config.learningProvider().isBlank()) {
+            String lp = config.learningProvider();
+            String lm = (config.learningModel() != null && !config.learningModel().isBlank())
+                    ? config.learningModel()
+                    : model;
+            String lApiKey = (config.learningApiKey() != null && !config.learningApiKey().isBlank())
+                    ? config.learningApiKey()
+                    : apiKey;
+            LlmClient rawLearning = "anthropic".equals(lp)
+                    ? LlmClientFactory.createAnthropicClient(
+                            lApiKey, config.refreshToken(), config.learningBaseUrl(),
+                            config.context1m(), config.extraAnthropicBetas())
+                    : LlmClientFactory.create(
+                            lp, lApiKey, config.refreshToken(), config.learningBaseUrl(), lm);
+            // Use the SAME circuit breaker instance so learning failures don't
+            // open a separate fault-isolation budget. Tradeoff: a flaky
+            // learning provider can trip the main user request path; in
+            // practice learning is non-interactive and can tolerate failures,
+            // so it's the less-bad side.
+            learningLlmClient = new CircuitBreakerLlmClient(rawLearning, circuitBreaker);
+            learningModelResolved = lm;
+            log.info("Learning LLM client built: provider={}, model={}, baseUrl={}",
+                    lp, lm, config.learningBaseUrl() != null ? config.learningBaseUrl() : "(default)");
+        } else {
+            learningLlmClient = llmClient;
+            learningModelResolved = model;
+            log.info("Learning LLM client: reusing main client (learningProvider unset)");
+        }
+
         // Register circuit breaker health check
         healthMonitor.register(new CircuitBreakerHealthCheck(circuitBreaker));
         log.info("LLM circuit breaker enabled: threshold={}, timeout={}s",
@@ -461,6 +497,11 @@ public final class AceCopilotDaemon {
         // (factory may translate or fall back, e.g. copilot ignores anthropic model names)
         String effectiveModel = "anthropic".equals(config.provider()) ? model : llmClient.defaultModel();
         agentHandler.setLlmConfig(llmClient, effectiveModel, systemPrompt);
+        // Phase 4 B1 (#6): if a separate learning client was built, route
+        // SkillRefinementEngine through it so its refinement proposals run
+        // on the configured learning provider. No-op when learningProvider
+        // is unset (setLearningLlmConfig guards on null/blank).
+        agentHandler.setLearningLlmConfig(learningLlmClient, learningModelResolved);
         agentHandler.setTokenConfig(config.maxTokens(), config.thinkingBudget(), config.maxTurns(), contextWindow);
         agentHandler.setContextAssemblyConfig(
                 markdownStore,
@@ -693,9 +734,14 @@ public final class AceCopilotDaemon {
             }
         }
 
+        // Phase 4 B1 (#6): use the learning LlmClient so skill generation
+        // runs off the configured learning provider (zero Copilot premium
+        // if learningProvider was set to anthropic/ollama/etc.).
         dynamicSkillGenerator = new DynamicSkillGenerator(
-                llmClient,
-                agentHandler::getModelForSession,
+                learningLlmClient,
+                sid -> (learningLlmClient == llmClient)
+                        ? agentHandler.getModelForSession(sid)
+                        : learningModelResolved,
                 skillRegistry);
         dynamicSkillGenerator.setLearningExplanationRecorder(learningExplanationRecorder);
         dynamicSkillGenerator.setLearningValidationRecorder(learningValidationRecorder);
@@ -1157,10 +1203,13 @@ public final class AceCopilotDaemon {
             return toReleaseJson(summary);
         });
 
-        // Session skill packer (extract successful workflow from session into skill draft)
+        // Session skill packer (extract successful workflow from session into skill draft).
+        // Phase 4 B1 (#6): uses the learning LlmClient — falls through to the main one
+        // when learningProvider is unset, so existing configs behave as before.
         int packBudget = SessionSkillPacker.deriveMaxConversationChars(contextWindow);
         var skillPacker = new SessionSkillPacker(
-                historyStore, sessionManager, llmClient, model, objectMapper, packBudget);
+                historyStore, sessionManager, learningLlmClient, learningModelResolved,
+                objectMapper, packBudget);
         router.register("skill.pack", params -> {
             if (params == null || !params.has("sessionId")) {
                 throw new IllegalArgumentException("Missing required parameter: sessionId");

--- a/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/AceCopilotDaemon.java
+++ b/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/AceCopilotDaemon.java
@@ -502,6 +502,15 @@ public final class AceCopilotDaemon {
         // on the configured learning provider. No-op when learningProvider
         // is unset (setLearningLlmConfig guards on null/blank).
         agentHandler.setLearningLlmConfig(learningLlmClient, learningModelResolved);
+        if ("session".equalsIgnoreCase(config.effectiveCopilotRuntime())
+                && (config.learningProvider() == null || config.learningProvider().isBlank())) {
+            log.warn(
+                "copilotRuntime='session' is active but learningProvider is unset — the post-turn "
+                + "learning pipeline (skill refinement, skill generation, session packer) will "
+                + "NOT run on session-mode turns. Set learningProvider to a non-Copilot provider "
+                + "(e.g. \"anthropic\" or \"ollama\") to keep learning working without eating "
+                + "Copilot premium. See docs/copilot-session-runtime.md (#6).");
+        }
         agentHandler.setTokenConfig(config.maxTokens(), config.thinkingBudget(), config.maxTurns(), contextWindow);
         agentHandler.setContextAssemblyConfig(
                 markdownStore,

--- a/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/StreamingAgentHandler.java
+++ b/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/StreamingAgentHandler.java
@@ -1532,9 +1532,28 @@ public final class StreamingAgentHandler {
         this.llmClient = llmClient;
         this.model = model;
         this.systemPrompt = systemPrompt;
+        // SkillRefinementEngine defaults to the main client; callers who want
+        // learning to run on a separate provider override this with
+        // setLearningLlmConfig (Phase 4 B1, #6).
         this.skillRefinementEngine = llmClient != null && model != null
                 ? new SkillRefinementEngine(llmClient, model, skillMetricsStore)
                 : null;
+    }
+
+    /**
+     * Phase 4 B1 (#6): rebuild {@link SkillRefinementEngine} with a
+     * dedicated learning LlmClient so the refinement pipeline runs off the
+     * operator's chosen learning provider instead of sharing the main
+     * user-path client. Call order: after {@link #setLlmConfig}.
+     * A {@code null} client is a no-op (keeps the default built by
+     * {@code setLlmConfig}).
+     */
+    public void setLearningLlmConfig(dev.acecopilot.core.llm.LlmClient learningClient, String learningModel) {
+        if (learningClient == null || learningModel == null || learningModel.isBlank()) {
+            return;
+        }
+        this.skillRefinementEngine = new SkillRefinementEngine(
+                learningClient, learningModel, skillMetricsStore);
     }
 
     /**

--- a/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/StreamingAgentHandler.java
+++ b/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/StreamingAgentHandler.java
@@ -24,12 +24,14 @@ import dev.acecopilot.core.agent.Tool;
 import dev.acecopilot.core.agent.ToolMetricsCollector;
 import dev.acecopilot.core.agent.ToolMetrics;
 import dev.acecopilot.core.agent.ToolRegistry;
+import dev.acecopilot.core.agent.Turn;
 import dev.acecopilot.core.llm.ContentBlock;
 import dev.acecopilot.core.llm.LlmException;
 import dev.acecopilot.core.llm.Message;
 import dev.acecopilot.core.llm.RequestAttribution;
 import dev.acecopilot.core.llm.RequestSource;
 import dev.acecopilot.core.llm.StopReason;
+import dev.acecopilot.core.llm.Usage;
 import dev.acecopilot.core.llm.StreamEvent;
 import dev.acecopilot.core.llm.StreamEventHandler;
 import dev.acecopilot.core.planner.AdaptiveReplanner;
@@ -1546,7 +1548,9 @@ public final class StreamingAgentHandler {
      * operator's chosen learning provider instead of sharing the main
      * user-path client. Call order: after {@link #setLlmConfig}.
      * A {@code null} client is a no-op (keeps the default built by
-     * {@code setLlmConfig}).
+     * {@code setLlmConfig}). Sets {@link #learningOnDedicatedProvider} so
+     * the session path can tell whether it is safe to schedule learning
+     * without eating Copilot premium.
      */
     public void setLearningLlmConfig(dev.acecopilot.core.llm.LlmClient learningClient, String learningModel) {
         if (learningClient == null || learningModel == null || learningModel.isBlank()) {
@@ -1554,7 +1558,11 @@ public final class StreamingAgentHandler {
         }
         this.skillRefinementEngine = new SkillRefinementEngine(
                 learningClient, learningModel, skillMetricsStore);
+        this.learningOnDedicatedProvider = true;
     }
+
+    /** True iff {@link #setLearningLlmConfig} installed a dedicated learning client. */
+    private volatile boolean learningOnDedicatedProvider = false;
 
     /**
      * Sets the token configuration for permission-aware agent loop creation.
@@ -2443,10 +2451,14 @@ public final class StreamingAgentHandler {
         copilotNode.put("runtime", "session");
         copilotNode.put("usageEventCount", r.usageEventCount());
         // Phase 4 audit: subsystems intentionally not invoked on this path.
-        // Downstream tooling can grep this to flag accidental regressions
-        // (e.g. if a future change wires post-turn learning into session
-        // mode without accounting for the extra premium it may incur).
-        copilotNode.put("subsystemsSkipped", "planner,compaction,post_turn_learning");
+        // post_turn_learning is re-enabled when a dedicated learning
+        // LlmClient is configured (B1, #6); left off otherwise so
+        // turning learning back on doesn't silently route through
+        // Copilot and eat premium again.
+        copilotNode.put("subsystemsSkipped",
+                learningOnDedicatedProvider
+                        ? "planner,compaction"
+                        : "planner,compaction,post_turn_learning");
         if (first != null && first.premiumUsed() != null) {
             copilotNode.put("premiumUsedBefore", first.premiumUsed());
             copilotNode.put("initiatorFirst", first.initiator());
@@ -2473,7 +2485,49 @@ public final class StreamingAgentHandler {
                 crossTurnPremiumDelta, r.intraTurnPremiumDelta(), r.usageEventCount(),
                 System.currentTimeMillis() - started);
 
+        // Phase 4 B1 (#6): run the post-turn learning pipeline off the
+        // dedicated learning LlmClient. Gate on learningOnDedicatedProvider
+        // so we don't silently route learning through Copilot (pre-B1
+        // behaviour kept learning off the session path for exactly this
+        // reason).
+        if (learningOnDedicatedProvider) {
+            var sessionMetricsCollector = sessionMetrics.get(sessionId);
+            schedulePostRequestLearning(
+                    sessionId,
+                    session.projectPath(),
+                    buildSyntheticSessionTurn(prompt, responseText, last),
+                    List.copyOf(session.messages()),
+                    sessionMetricsCollector != null
+                            ? sessionMetricsCollector.allMetrics()
+                            : Map.of(),
+                    Set.of());
+        }
+
         return result;
+    }
+
+    /**
+     * Phase 4 B1 (#6): the post-turn learning pipeline was built around
+     * the chat-path {@link Turn} record. Session mode doesn't produce one
+     * natively (the SDK agent returns {@code content + stopReason}), so
+     * synthesise the minimum viable shape: user + assistant messages,
+     * token usage from the last SDK usage snapshot, one billable LLM
+     * request tagged {@code MAIN_TURN}. Downstream consumers
+     * ({@link SkillRefinementEngine}, {@link DynamicSkillGenerator},
+     * {@link SessionSkillPacker}) only read {@code newMessages},
+     * {@code totalUsage}, and {@code finalStopReason}, so the rest stays
+     * at default / empty.
+     */
+    private Turn buildSyntheticSessionTurn(String prompt, String responseText,
+                                           CopilotAcpClient.UsageSnapshot last) {
+        var messages = new java.util.ArrayList<Message>(2);
+        if (prompt != null && !prompt.isBlank()) messages.add(Message.user(prompt));
+        if (responseText != null && !responseText.isBlank()) messages.add(Message.assistant(responseText));
+        int inTok = (last != null && last.inputTokens() != null) ? last.inputTokens().intValue() : 0;
+        int outTok = (last != null && last.outputTokens() != null) ? last.outputTokens().intValue() : 0;
+        var usage = new Usage(inTok, outTok);
+        var attribution = RequestAttribution.builder().record(RequestSource.MAIN_TURN).build();
+        return new Turn(messages, StopReason.END_TURN, usage, null, false, false, null, 1, attribution);
     }
 
     public void awaitSessionPostProcessing(String sessionId) {

--- a/docs/copilot-phase4-audit.md
+++ b/docs/copilot-phase4-audit.md
@@ -39,7 +39,7 @@ consequences:
 | Upfront planner | Fires on complex prompts → +1 premium | **Silently skipped.** SDK agent plans internally if it decides to |
 | Fallback / replan | Fires on plan-step failure → +N premium | **Silently skipped.** No plan exists |
 | Compaction summary | Fires mid-turn if context overflows → +1 premium | **Silently skipped.** SDK manages context itself |
-| Post-turn learning (skill refine / generate / pack) | Fires after every turn → +1-3 premium and background work | **Silently skipped.** No learning happens on session prompts |
+| Post-turn learning (skill refine / generate / pack) | Fires after every turn → +1-3 premium and background work | **Conditional.** PR B1 (#6) lets operators set `learningProvider` to a non-Copilot provider; when set, session-mode turns schedule learning on that client and incur 0 Copilot premium. When unset (default), learning stays off on session path and the daemon logs a WARN at startup. |
 
 Phase 3's 1-premium-per-turn claim is therefore accurate for session
 mode, but the user also silently loses four capabilities that chat

--- a/docs/copilot-session-runtime.md
+++ b/docs/copilot-session-runtime.md
@@ -30,6 +30,42 @@ Defaults to `"chat"` — existing installs see no change. The legacy
 `copilotRuntimeAcceptUnsandboxed` field is accepted for backward compat
 but is a no-op; daemon logs an info line if it is still present.
 
+### Post-turn learning on session mode (Phase 4 B1, #6)
+
+By default, session mode skips the post-turn learning pipeline (skill
+refinement, dynamic skill generation, session skill packer) — those
+components call `LlmClient.sendMessage` directly and would otherwise
+eat Copilot premium per turn. To keep learning running without that
+cost, configure a dedicated learning provider:
+
+```json
+{
+  "profiles": {
+    "copilot": {
+      "provider": "copilot",
+      "copilotRuntime": "session",
+      "copilotRuntimeAcceptUnsandboxed": true,
+      "apiKey": "<GitHub token>",
+
+      "learningProvider": "anthropic",
+      "learningModel": "claude-haiku-4.5",
+      "learningApiKey": "<Anthropic key, or reuse a cached OAuth>"
+    }
+  }
+}
+```
+
+Supported: any provider `LlmClientFactory.create(...)` accepts —
+`"anthropic"`, `"ollama"`, `"openai"`, `"openai-codex"`. Setting
+`learningProvider: "copilot"` is rejected with an ERROR at load time
+(defeats the purpose). When unset, the daemon logs a WARN at startup
+explaining that session-mode learning is off.
+
+The learning provider is wrapped in the **same** circuit breaker as
+the main client. A flaky learning provider can trip the main breaker —
+a deliberate tradeoff so background learning failures are visible and
+bounded, not quietly degrading.
+
 ## Requirements
 
 - Node.js 20+ on `PATH`. Daemon preflights this at startup; missing


### PR DESCRIPTION
First implementation half of #6: recover the post-turn learning pipeline on session mode without charging the user's Copilot premium for it. Audit PR (#17) already set the stage; this is the first behavioural change.

## Motivation

Phase 3 locked in "session mode = 1 premium per user turn", but the Phase 4 audit (#17) surfaced that this was partly achieved by silently skipping post-turn learning on the session path entirely — no skill refinement, no dynamic skill generation, no session packer. Restoring those through the main \`LlmClient\` would bring their per-turn LLM calls back onto the user's Copilot bill (defeating Phase 3). So B1 adds a second, dedicated \`LlmClient\` just for learning.

## What changes

### Config

- \`learningProvider\` (optional string) — the only opt-in key. \`"anthropic"\`, \`"ollama"\`, etc. Setting it to \`"copilot"\` is rejected at load time with a clear error.
- \`learningBaseUrl\`, \`learningApiKey\`, \`learningModel\` fall through to the main equivalents when unset.

### Daemon

- When \`learningProvider\` is set, \`AceCopilotDaemon\` builds a second \`LlmClient\` via \`LlmClientFactory\` (special-cased for \`anthropic\` to match the main-client code path).
- Wraps it in the **same** \`CircuitBreakerLlmClient\` as the main client (single budget — a flaky learning provider can trip the main breaker; deliberate tradeoff so background failures stay visible, not silently degraded).
- \`DynamicSkillGenerator\` and \`SessionSkillPacker\` receive this learning client at construction. \`StreamingAgentHandler\` gains \`setLearningLlmConfig(...)\` which rebuilds \`SkillRefinementEngine\` with the learning client.
- Startup WARN when \`copilotRuntime=session\` is active and \`learningProvider\` is unset: learning is off until the operator opts in.

### Session-path wiring

- \`handlePromptViaCopilotSession\` gates on \`learningOnDedicatedProvider\` (set iff \`setLearningLlmConfig\` was called with a non-null client).
- When true, synthesises a minimal \`Turn\` from the session response (user + assistant messages, usage from the last SDK snapshot, 1 \`MAIN_TURN\` attribution) and calls \`schedulePostRequestLearning\`. The chat-path pipeline only reads \`newMessages\`, \`totalUsage\`, \`finalStopReason\`, so this is enough to drive all three learning components.
- \`usage.copilot.subsystemsSkipped\` now drops \`"post_turn_learning"\` from its list when learning is live, so the regression marker reflects reality.

### Docs

- \`docs/copilot-session-runtime.md\` gains a "Post-turn learning on session mode" section with config, supported values, the \`learningProvider=copilot\` rejection rule, and the circuit-breaker tradeoff.
- \`docs/copilot-phase4-audit.md\` row for post-turn learning changes from "silently skipped" to "conditional" with PR B1 referenced.

## Deliberately out of scope

- **Planner spike (PR B2)** — the actual call to run planner / use in-session steering for complex prompts. Unrelated logic path.
- **Compaction** — stays dropped, SDK handles context internally. Closed in audit.
- **Verifying learning quality with a non-Copilot model** — the provider split is orthogonal to model selection. Operators pick \`learningModel\` at their discretion.
- **Split circuit breakers** — one failing learning call tripping the main path is a real risk; deferred on purpose so background failures don't hide.

## Test plan

- [x] \`./gradlew build\` passes
- [ ] Reviewer: configure \`learningProvider: "anthropic"\` + Anthropic key, run a session-mode prompt, confirm \`usage.copilot.subsystemsSkipped\` contains \`"planner,compaction"\` (not \`...,post_turn_learning\`) and the daemon log shows learning components firing against Anthropic
- [ ] Reviewer: same setup but omit \`learningProvider\`, confirm the startup WARN fires and session turns skip learning (back to pre-B1 behaviour)
- [ ] Reviewer: confirm chat mode still uses the main client for learning (no regression for existing installs)

Closes nothing. PR B2 (planner decision spike) then closes #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)