### PR TITLE
feat(cli): session-total premium line alongside per-turn line (#20)

### DIFF
--- a/ace-copilot-cli/src/main/java/dev/acecopilot/cli/TerminalRepl.java
+++ b/ace-copilot-cli/src/main/java/dev/acecopilot/cli/TerminalRepl.java
@@ -1479,9 +1479,14 @@ public final class TerminalRepl {
             return;
         }
         long total = current - sessionPremiumBaseline;
+        // Wording deliberately scoped to "this TUI attached": the baseline
+        // is captured from the first turn this CLI process observes, so a
+        // reattach (or any attachment that misses the true first turn)
+        // would undercount a "since session start" claim. Cross-reattach
+        // totals need daemon-side baseline plumbing (out of scope for #20).
         String tag = total > 0
-                ? WARNING + "copilot: session total +" + total + " since session start" + RESET
-                : MUTED + "copilot: session total unchanged since session start" + RESET;
+                ? WARNING + "copilot: total +" + total + " since this TUI attached" + RESET
+                : MUTED + "copilot: no change since this TUI attached" + RESET;
         String absolute = sessionPremiumBaseline + "→" + current;
         out.printf("  %s  %s%n", tag, MUTED + "premiumUsed " + absolute + RESET);
     }

--- a/ace-copilot-cli/src/main/java/dev/acecopilot/cli/TerminalRepl.java
+++ b/ace-copilot-cli/src/main/java/dev/acecopilot/cli/TerminalRepl.java
@@ -181,6 +181,14 @@ public final class TerminalRepl {
     private volatile long deferEventSeq;
     /** Last consumed skill draft event sequence from daemon. */
     private volatile long skillDraftEventSeq;
+    /**
+     * Copilot `premium_interactions.usedRequests` captured on the first
+     * session-runtime turn of this CLI attachment. Used as the baseline
+     * for the session-total line (#20). -1 means "no baseline yet".
+     * Ephemeral — resets whenever this REPL process starts; does not
+     * survive a TUI reattach.
+     */
+    private long sessionPremiumBaseline = -1L;
 
     private sealed interface UiEvent permits UiNoticeEvent, UiPrintAboveEvent {}
 
@@ -1443,7 +1451,39 @@ public final class TerminalRepl {
             note = "(billable activity at some point in the window — attribution may span this turn or the prior turn's delayed accounting)";
         }
         out.printf("  %s  %s  %s%s%n", tag, MUTED + "premiumUsed " + absolute + RESET, MUTED, note);
+        renderCopilotSessionTotalLine(out, copilot);
         out.print(RESET);
+    }
+
+    /**
+     * Session-total companion to the per-turn line (#20). Captures a
+     * baseline from the first session-runtime turn observed by this CLI
+     * attachment, then prints cumulative counter advance from that
+     * baseline on every subsequent turn. Summed across many turns the
+     * total is more reliable than any individual per-turn delta — the
+     * eventually-consistent per-turn noise averages out.
+     */
+    private void renderCopilotSessionTotalLine(PrintWriter out, JsonNode copilot) {
+        long baselineCandidate = copilot.has("premiumUsedBefore")
+                ? copilot.get("premiumUsedBefore").asLong(-1)
+                : copilot.path("premiumUsedAfter").asLong(-1);
+        if (baselineCandidate < 0) {
+            return;
+        }
+        if (sessionPremiumBaseline < 0) {
+            sessionPremiumBaseline = baselineCandidate;
+            return;
+        }
+        long current = copilot.path("premiumUsedAfter").asLong(-1);
+        if (current < 0) {
+            return;
+        }
+        long total = current - sessionPremiumBaseline;
+        String tag = total > 0
+                ? WARNING + "copilot: session total +" + total + " since session start" + RESET
+                : MUTED + "copilot: session total unchanged since session start" + RESET;
+        String absolute = sessionPremiumBaseline + "→" + current;
+        out.printf("  %s  %s%n", tag, MUTED + "premiumUsed " + absolute + RESET);
     }
 
     // -- Permission handling (from bridge) -----------------------------------


### PR DESCRIPTION
Closes #20.

## What

Adds a second line under every session-runtime turn's existing per-turn billing line:

```
  copilot: session counter +1 since last turn  premiumUsed 42→43  (…)
  copilot: session total +3 since session start  premiumUsed 40→43
```

## Why

Phase 4 (#6) locked a Copilot-only + savings-first policy. Operators now need a **visible premium budget** to verify the policy is actually holding in practice. The existing per-turn line is noisy — GitHub's `premium_interactions.usedRequests` counter is eventually consistent, so a billable turn's +1 can land in a later turn's observation window. The session-total amortizes that noise: summed across many turns it converges to the real consumption, which is actually more trustworthy than any single-turn delta.

## How

CLI-only change in `TerminalRepl`:

- New field `sessionPremiumBaseline` (ephemeral per CLI attachment).
- On the first session-runtime turn observed, capture `premiumUsedBefore` (or `premiumUsedAfter` as fallback) as the baseline and print nothing extra.
- On every subsequent turn, print `session total +N since session start  premiumUsed X→Y` where `N = currentAfter - baseline`.
- Wording stays observable-only, same discipline as the per-turn line — no causal attribution.

## Tradeoff

Baseline is per-CLI-attachment. TUI restart → baseline resets. If operators later ask for cross-reattach totals, follow up with daemon-side plumbing in `SessionManager`. Noted in the issue as explicit out-of-scope.

## Test plan

- [ ] `./restart.sh copilot` then run 3–5 session-mode prompts, confirm session-total line appears from turn 2 onward and its value equals the running sum of per-turn deltas
- [ ] Confirm no session-total line on turn 1 (baseline-only)
- [ ] Confirm chat-path turns still render nothing (guard is unchanged — runtime="session" gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)