### PR TITLE
fix(cli): two session-mode telemetry display bugs

### DIFF
--- a/ace-copilot-cli/src/main/java/dev/acecopilot/cli/TerminalRepl.java
+++ b/ace-copilot-cli/src/main/java/dev/acecopilot/cli/TerminalRepl.java
@@ -1338,6 +1338,37 @@ public final class TerminalRepl {
      * <p>Skips any entry whose source key is blank or whose count is non-positive — the
      * daemon shouldn't send these, but the CLI shouldn't trust its input implicitly.
      */
+    /**
+     * Resolves the per-call input-token count for ContextMonitor sampling.
+     *
+     * <p>Streaming chat turns receive live {@code stream.usage} notifications
+     * during the turn (see {@link TaskStreamReader}), which updates
+     * {@link TaskHandle#liveInputTokens()}. That value is preferred.
+     *
+     * <p>The Copilot session path doesn't emit {@code stream.usage} today —
+     * {@link dev.acecopilot.daemon.StreamingAgentHandler}'s listener only fires
+     * on the chat path — so {@code liveInputTokens} stays 0 for an entire
+     * session turn. On that path {@code usage.inputTokens} is the last
+     * {@code assistant.usage} event's per-call value (not cumulative as on
+     * chat), so it's safe to use as a fallback. Gated strictly on
+     * {@code copilot.runtime == "session"} so we never feed the chat path's
+     * cumulative number back into the monitor.
+     *
+     * <p>Used by both the foreground {@link #renderTaskCompletion} path and
+     * the background auto-push path — they need symmetric behavior or the
+     * session-mode context bar silently breaks whenever a long task ends in
+     * the background.
+     */
+    private static long resolvePerCallContext(TaskHandle handle, JsonNode usage) {
+        long perCallContext = handle.liveInputTokens();
+        if (perCallContext > 0) return perCallContext;
+        if (usage == null) return 0L;
+        JsonNode copilotNode = usage.path("copilot");
+        if (!"session".equals(copilotNode.path("runtime").asText(""))) return 0L;
+        long sessionInput = usage.path("inputTokens").asLong(0);
+        return sessionInput > 0 ? sessionInput : 0L;
+    }
+
     private static Map<String, Integer> parseLlmRequestsBySource(JsonNode usage) {
         if (usage == null) return Map.of();
         JsonNode bySource = usage.path("llmRequestsBySource");
@@ -1370,23 +1401,7 @@ public final class TerminalRepl {
             // The JSON-RPC result's inputTokens is cumulative across all API calls in the turn,
             // NOT the per-call value — using it would cause erratic usage % jumps.
             // If no streaming usage was received, keep the monitor's existing per-call value (0 means "no update").
-            long perCallContext = handle.liveInputTokens();
-            // Copilot session path doesn't emit stream.usage notifications today
-            // (StreamingAgentHandler only sends them from the chat-path listener),
-            // so liveInputTokens stays 0 and the context bar reads 0/128K. On
-            // that path usage.inputTokens is the last assistant.usage event's
-            // per-call value — not cumulative — so it's safe to use as fallback.
-            // Gate strictly on runtime="session" so we don't accidentally feed
-            // the chat path's cumulative number back into the monitor.
-            if (perCallContext <= 0) {
-                var copilotNode = usage.path("copilot");
-                if ("session".equals(copilotNode.path("runtime").asText(""))) {
-                    long sessionInput = usage.path("inputTokens").asLong(0);
-                    if (sessionInput > 0) {
-                        perCallContext = sessionInput;
-                    }
-                }
-            }
+            long perCallContext = resolvePerCallContext(handle, usage);
             // Parse once; this parsed map is fed to the session monitor below (on the first
             // render only, via markUsageAccounted) AND to the per-turn display formatter
             // below (on every render, since display is idempotent across re-renders).
@@ -1853,7 +1868,7 @@ public final class TerminalRepl {
                     int bgTurnIn = bgUsage.path("inputTokens").asInt(0);
                     int bgTurnOut = bgUsage.path("outputTokens").asInt(0);
                     int bgLlmRequests = bgUsage.path("llmRequests").asInt(0);
-                    long bgPerCall = handle.liveInputTokens();
+                    long bgPerCall = resolvePerCallContext(handle, bgUsage);
                     contextMonitor.recordTurnComplete(bgTurnIn, bgTurnOut, bgPerCall);
                     contextMonitor.recordLlmRequests(bgLlmRequests);
                     contextMonitor.recordLlmRequestsBySource(parseLlmRequestsBySource(bgUsage));

--- a/ace-copilot-cli/src/main/java/dev/acecopilot/cli/TerminalRepl.java
+++ b/ace-copilot-cli/src/main/java/dev/acecopilot/cli/TerminalRepl.java
@@ -1371,6 +1371,22 @@ public final class TerminalRepl {
             // NOT the per-call value — using it would cause erratic usage % jumps.
             // If no streaming usage was received, keep the monitor's existing per-call value (0 means "no update").
             long perCallContext = handle.liveInputTokens();
+            // Copilot session path doesn't emit stream.usage notifications today
+            // (StreamingAgentHandler only sends them from the chat-path listener),
+            // so liveInputTokens stays 0 and the context bar reads 0/128K. On
+            // that path usage.inputTokens is the last assistant.usage event's
+            // per-call value — not cumulative — so it's safe to use as fallback.
+            // Gate strictly on runtime="session" so we don't accidentally feed
+            // the chat path's cumulative number back into the monitor.
+            if (perCallContext <= 0) {
+                var copilotNode = usage.path("copilot");
+                if ("session".equals(copilotNode.path("runtime").asText(""))) {
+                    long sessionInput = usage.path("inputTokens").asLong(0);
+                    if (sessionInput > 0) {
+                        perCallContext = sessionInput;
+                    }
+                }
+            }
             // Parse once; this parsed map is fed to the session monitor below (on the first
             // render only, via markUsageAccounted) AND to the per-turn display formatter
             // below (on every render, since display is idempotent across re-renders).
@@ -1442,7 +1458,7 @@ public final class TerminalRepl {
         String note;
         if (delta < 0) {
             tag = MUTED + "copilot: first turn of session (no baseline yet)" + RESET;
-            note = "premiumUsed " + absolute;
+            note = "(per-turn delta starts next turn)";
         } else if (delta == 0) {
             tag = MUTED + "copilot: session counter unchanged since last turn" + RESET;
             note = "(no billable activity surfaced in this window — this turn or a prior turn may still have pending accounting)";


### PR DESCRIPTION
Both bugs were observed live in a single session-mode turn and affect how operators read the Phase 4 savings story. CLI-only fixes.

## Bug 1: duplicate premiumUsed on first-turn line

First session-mode turn rendered:

```
copilot: first turn of session (no baseline yet)  premiumUsed 222→222  premiumUsed 222→222
```

`renderCopilotBillingLine`'s `delta < 0` branch was setting `note = "premiumUsed " + absolute`, and the printf format already has a dedicated \`%s\` column for the absolute string. So it printed twice.

Pre-existing bug — #20's session-total renderer runs after and is unaffected. Replace `note` with a forward-looking explanation (\`\"(per-turn delta starts next turn)\"\`) so the layout still reads cleanly.

## Bug 2: context bar stuck at 0/128K on session path

The Copilot session path never emits \`stream.usage\` notifications — \`StreamingAgentHandler.onUsageUpdate\` at line ~3715 lives on the chat-path listener only. So the CLI's \`handle.liveInputTokens\` stays 0 through the whole turn, \`renderTaskCompletion\` feeds 0 to the monitor as \`perCallContext\`, and no sample ever lands.

The session result *does* carry \`usage.inputTokens\` — derived from \`last.inputTokens()\` on that path, which is the last \`assistant.usage\` event's per-call value (not cumulative). Safe to use as fallback.

Gate strictly on \`copilot.runtime == \"session\"\` so the chat path's cumulative \`usage.inputTokens\` doesn't leak back in — that's the trap the existing comment warns about.

## Trade-off noted

This fix only updates the context bar at **turn end** on session mode. Real-time streaming updates would need the daemon to forward \`session/usage\` events as \`stream.usage\` notifications — a bigger change. If operators later want live-streaming context %, follow up with a daemon-side change to wire session/usage → stream.usage.

## Test plan

- [ ] Run a session-mode prompt, confirm first-turn line shows \`premiumUsed X→X  (per-turn delta starts next turn)\` (one absolute, not two)
- [ ] Confirm context bar updates at turn end on session path (non-zero), matching the turn's input tokens
- [ ] Confirm chat path still shows real-time context % during streaming (unchanged behavior)
- [ ] Confirm subsequent session turns show \`session counter +N since last turn\` and the session-total line from #20 both render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)