### PR TITLE
docs(readme): swap GraalVM badge for npm, trim redundant pre-flight list

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <p align="center">
   <a href="https://github.com/xinhuagu/ace-copilot/actions/workflows/ci.yml"><img src="https://github.com/xinhuagu/ace-copilot/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <img src="https://img.shields.io/badge/Java-21-orange?logo=openjdk" alt="Java 21">
-  <img src="https://img.shields.io/badge/GraalVM-Native_Image-blue?logo=oracle" alt="GraalVM">
+  <img src="https://img.shields.io/badge/Node.js-20%2B-339933?logo=node.js&logoColor=white" alt="Node.js 20+">
   <img src="https://img.shields.io/badge/Gradle-8.14-02303A?logo=gradle&logoColor=white" alt="Gradle 8.14">
 </p>
 
@@ -99,11 +99,6 @@ ace-copilot                    # Attach TUI
 ```
 
 #### First-time login
-
-On first start, ace-copilot only treats the following as "already logged in" and skips the prompt:
-
-1. `~/.ace-copilot/copilot-oauth-token` — token cached from a previous login
-2. `gh auth token` — a working GitHub CLI session
 
 **Easiest path:** run `gh auth login` once, then start ace-copilot. No prompt.
 


### PR DESCRIPTION
## Summary

Two small README tweaks.

### Badges
- **Removed:** GraalVM Native Image badge (it's an optional build path, not a day-one runtime requirement)
- **Added:** `npm / Node 20+` badge (Node is a hard requirement for the Copilot session sidecar, already called out in `install.sh` prose)

### First-time login section
- **Removed:** the explicit "On first start ace-copilot only treats the following as logged in" two-item list at the top.

The same information already appears one paragraph below — in the *Easiest path* line, the device-code fallback prose, and the env/config callout. The bullet list at the top was redundant and made the section feel longer than the decision actually is.

## Test plan

- [ ] Verify badges render in GitHub README preview
- [ ] Verify the trimmed *First-time login* section still reads end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)
