### PR TITLE
feat(copilot): default to claude-haiku-4.5, document model selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,18 @@ Open the URL, paste the code, authorize. The token is cached and reused.
 >
 > **About env vars and config tokens.** ace-copilot will happily *use* a token from `apiKey` (in `~/.ace-copilot/config.json`), `GITHUB_TOKEN`, or `GH_TOKEN` once it's running — but these **do not** count as "logged in" on first start. A fresh install always shows the device-code prompt unless a cached token or `gh auth login` is present. When more than one source is set, the cached token and `gh auth token` win at runtime too, so the account that passed the first-time prompt is the same account billed for Copilot quota. Config / env tokens only kick in when no cached or `gh` token exists. This is on purpose: you should see and confirm exactly which GitHub account ace-copilot is binding to before it starts spending your Copilot quota.
 
+#### Choose a model
+
+Default is **`claude-haiku-4.5`** — the only Copilot model with a 1× session-mode multiplier (every other model is 3×). For most agent work this is the cheapest competent choice; switch up only when capability justifies the cost. See the multiplier matrix in [The problem, concretely](#the-problem-concretely) above.
+
+| When you want to choose | How | Example |
+|---|---|---|
+| **At startup** (one-shot for this run) | `ACE_COPILOT_MODEL` env var on the launch command | `ACE_COPILOT_MODEL=claude-sonnet-4.5 ace-copilot` |
+| **Mid-session** (try a model for the next turn) | `/model <name>` at the prompt | `/model claude-opus-4.6` |
+| **Permanently** (every future launch) | `model` field in the copilot profile of `~/.ace-copilot/config.json` | `"model": "claude-sonnet-4.6"` |
+
+Common Copilot model names: `claude-haiku-4.5`, `claude-sonnet-4.5`, `claude-sonnet-4.6`, `claude-opus-4.6`, `gpt-4o`, `gpt-5.2-codex`, `o4-mini`. Full list and per-model notes in [docs/provider-configuration.md](docs/provider-configuration.md#available-models).
+
 #### Per-turn output
 
 First turn prints `copilot: first turn of session (no baseline yet)`. Every subsequent turn shows the per-turn and session-total lines above.

--- a/ace-copilot-llm/src/main/java/dev/acecopilot/llm/LlmClientFactory.java
+++ b/ace-copilot-llm/src/main/java/dev/acecopilot/llm/LlmClientFactory.java
@@ -42,7 +42,7 @@ public final class LlmClientFactory {
             "groq", "llama-3.3-70b-versatile",
             "together", "meta-llama/Llama-3.3-70B-Instruct-Turbo",
             "mistral", "mistral-large-latest",
-            "copilot", "claude-sonnet-4.5",
+            "copilot", "claude-haiku-4.5",
             "ollama", "qwen3:4b"
     );
 
@@ -137,7 +137,7 @@ public final class LlmClientFactory {
     private static LlmClient createCopilotClient(String githubToken, String baseUrl, String model) {
         var tokenProvider = new CopilotTokenProvider(githubToken);
         String resolvedBaseUrl = baseUrl != null ? baseUrl : DEFAULT_BASE_URLS.get("copilot");
-        String defaultModel = DEFAULT_MODELS.getOrDefault("copilot", "claude-sonnet-4.5");
+        String defaultModel = DEFAULT_MODELS.getOrDefault("copilot", "claude-haiku-4.5");
 
         // If model is an Anthropic-native name (from global config), ignore it — use copilot default.
         // Users can still explicitly set a copilot model via profile config or /model command.

--- a/docs/provider-configuration.md
+++ b/docs/provider-configuration.md
@@ -41,7 +41,7 @@ Or configure a PAT in `~/.ace-copilot/config.json`:
         "copilot": {
             "provider": "copilot",
             "apiKey": "ghp_your_personal_access_token",
-            "model": "claude-sonnet-4.5",
+            "model": "claude-haiku-4.5",
             "maxTokens": 16384,
             "thinkingBudget": 0,
             "contextWindowTokens": 200000
@@ -66,16 +66,18 @@ Copilot exposes models from multiple providers. Use `/model <name>` at runtime t
 
 ace-copilot automatically routes requests to the correct API endpoint — Codex models use the Responses API (`/responses`), all others use Chat Completions (`/chat/completions`).
 
-> **Model name format:** Copilot uses dot-notation for versions (`claude-opus-4.6`), while Anthropic direct API uses hyphen-notation (`claude-opus-4-6`). When switching between providers, use the format for the active provider. If the global config has an Anthropic-format model name (e.g. `claude-opus-4-6`), the Copilot provider ignores it and uses its own default (`claude-sonnet-4.5`).
+> **Model name format:** Copilot uses dot-notation for versions (`claude-opus-4.6`), while Anthropic direct API uses hyphen-notation (`claude-opus-4-6`). When switching between providers, use the format for the active provider. If the global config has an Anthropic-format model name (e.g. `claude-opus-4-6`), the Copilot provider ignores it and uses its own default (`claude-haiku-4.5`).
 
 ### Default Model Behavior
 
 When using `./dev.sh copilot`, the model is resolved as follows:
 - If a **copilot profile** exists in config with a `model` field → use that model
-- If only a **global model** exists and it is an Anthropic-native name → ignore it, use `claude-sonnet-4.5`
-- If no model is configured → use `claude-sonnet-4.5`
+- If only a **global model** exists and it is an Anthropic-native name → ignore it, use `claude-haiku-4.5`
+- If no model is configured → use `claude-haiku-4.5`
 
-This means you can keep `"model": "claude-opus-4-6"` in your global config for Anthropic direct API, and `./dev.sh copilot` will still use `claude-sonnet-4.5` without conflict.
+`claude-haiku-4.5` is the default because it is the only Copilot model with a session-mode multiplier of 1× (others are 3×). For most agent workloads it is the cheapest competent option; switch up only when capability justifies the cost. See the README billing table for the full multiplier matrix.
+
+This also means you can keep `"model": "claude-opus-4-6"` in your global config for Anthropic direct API, and `./dev.sh copilot` will still use `claude-haiku-4.5` without conflict.
 
 ### Running
 


### PR DESCRIPTION
## Summary

Two changes to cut day-one Copilot quota burn and make model selection visible.

### 1. Default copilot model: Sonnet 4.5 → Haiku 4.5

Per the README billing table, Haiku 4.5 is the **only** Copilot model with a 1× session-mode multiplier — every other model (Sonnet 4.5/4.6, Opus, GPT family) bills at 3×. A fresh install that never touches the model field now spends ~1/3 the premium quota per turn.

Existing configs with an explicit `model` field are untouched.

Both the `DEFAULT_MODELS` map and the duplicated fallback string in `createCopilotClient` are updated together so they cannot drift apart.

### 2. README: new "Choose a model" subsection

Three ways to override, in one short table:

| How | When | Example |
|---|---|---|
| `/model <name>` at the prompt | Try a model for one session | `/model claude-sonnet-4.5` |
| `model` in `~/.ace-copilot/config.json` copilot profile | Set a permanent default | `"model": "claude-sonnet-4.6"` |
| `ACE_COPILOT_MODEL` env var | One-shot override at launch | `ACE_COPILOT_MODEL=gpt-5.2-codex ace-copilot` |

Plus a list of common Copilot model names and a link to the full table in `docs/provider-configuration.md`.

`docs/provider-configuration.md` is updated in the same pass so the "Default Model Behavior" section matches the new code default and explains why Haiku is the baseline.

## Test plan

- [x] `./gradlew :ace-copilot-llm:test :ace-copilot-daemon:test :ace-copilot-cli:test` passes
- [ ] Manual: fresh install with no `model` in config → daemon reports `claude-haiku-4.5` in `daemon status`
- [ ] Manual: `/model claude-sonnet-4.5` at the prompt switches mid-session

🤖 Generated with [Claude Code](https://claude.com/claude-code)
