### PR TITLE
fix(tui): sync displayed model with daemon per-turn response

### DIFF
--- a/ace-copilot-cli/src/main/java/dev/acecopilot/cli/TerminalRepl.java
+++ b/ace-copilot-cli/src/main/java/dev/acecopilot/cli/TerminalRepl.java
@@ -1391,6 +1391,16 @@ public final class TerminalRepl {
         if (message == null) return;
 
         JsonNode result = message.get("result");
+        if (result != null) {
+            // Daemon reports the model it actually used for this turn. Treat
+            // that as truth — the cached startup value can go stale across
+            // daemon restarts, profile changes, or per-session overrides the
+            // TUI didn't originate.
+            String actualModel = result.path("model").asText("");
+            if (!actualModel.isEmpty() && !actualModel.equals(effectiveModel)) {
+                effectiveModel = actualModel;
+            }
+        }
         if (result != null && result.has("usage")) {
             var usage = result.get("usage");
             int turnIn = usage.path("inputTokens").asInt(0);

--- a/ace-copilot-cli/src/main/java/dev/acecopilot/cli/TerminalRepl.java
+++ b/ace-copilot-cli/src/main/java/dev/acecopilot/cli/TerminalRepl.java
@@ -1386,21 +1386,32 @@ public final class TerminalRepl {
         return parsed;
     }
 
+    /**
+     * Adopts the model reported by the daemon for this turn as the displayed
+     * model. The cached startup value goes stale across daemon restarts,
+     * profile changes, and overrides the TUI didn't originate; the daemon
+     * echoes the model it actually used in every agent.prompt result.
+     *
+     * <p>Must be called from every terminal-completion path — foreground,
+     * auto-backgrounded, and late-notified — since they don't share a
+     * rendering chokepoint.
+     */
+    private void syncEffectiveModelFromResult(JsonNode rpcMessage) {
+        if (rpcMessage == null) return;
+        JsonNode result = rpcMessage.get("result");
+        if (result == null) return;
+        String actualModel = result.path("model").asText("");
+        if (!actualModel.isEmpty() && !actualModel.equals(effectiveModel)) {
+            effectiveModel = actualModel;
+        }
+    }
+
     private void renderTaskCompletion(PrintWriter out, TaskHandle handle) {
         JsonNode message = handle.result();
         if (message == null) return;
 
+        syncEffectiveModelFromResult(message);
         JsonNode result = message.get("result");
-        if (result != null) {
-            // Daemon reports the model it actually used for this turn. Treat
-            // that as truth — the cached startup value can go stale across
-            // daemon restarts, profile changes, or per-session overrides the
-            // TUI didn't originate.
-            String actualModel = result.path("model").asText("");
-            if (!actualModel.isEmpty() && !actualModel.equals(effectiveModel)) {
-                effectiveModel = actualModel;
-            }
-        }
         if (result != null && result.has("usage")) {
             var usage = result.get("usage");
             int turnIn = usage.path("inputTokens").asInt(0);
@@ -1871,6 +1882,7 @@ public final class TerminalRepl {
             // Guarded: a subsequent /fg on this already-completed handle would re-enter
             // renderTaskCompletion and try to account again; see markUsageAccounted contract.
             JsonNode bgResult = handle.result();
+            syncEffectiveModelFromResult(bgResult);
             if (bgResult != null && handle.markUsageAccounted()) {
                 JsonNode bgUsageResult = bgResult.get("result");
                 if (bgUsageResult != null && bgUsageResult.has("usage")) {
@@ -1946,6 +1958,8 @@ public final class TerminalRepl {
             if (!handle.isTerminal()) continue;
             if (handle.taskId().equals(taskManager.foregroundTaskId())) continue;
             if (!handle.markNotified()) continue;  // already shown — skip
+
+            syncEffectiveModelFromResult(handle.result());
 
             String stateLabel = switch (handle.state()) {
                 case COMPLETED -> SUCCESS + "completed" + RESET;

--- a/ace-copilot-cli/src/main/java/dev/acecopilot/cli/TerminalRepl.java
+++ b/ace-copilot-cli/src/main/java/dev/acecopilot/cli/TerminalRepl.java
@@ -129,6 +129,14 @@ public final class TerminalRepl {
     /** Tracks the effective model, updated after successful model switches. */
     private volatile String effectiveModel;
 
+    /**
+     * Timestamp of the last successful local {@code /model} switch. Used to
+     * ignore completion-sync from background tasks that started before the
+     * user's explicit switch — otherwise a stale background completion
+     * would revert the status bar to the pre-switch model.
+     */
+    private volatile Instant lastLocalSwitchAt;
+
     /** LineReader reference for use during permission prompts. */
     private volatile LineReader activeReader;
 
@@ -1395,9 +1403,17 @@ public final class TerminalRepl {
      * <p>Must be called from every terminal-completion path — foreground,
      * auto-backgrounded, and late-notified — since they don't share a
      * rendering chokepoint.
+     *
+     * <p>A stale completion is ignored when the user has since run a local
+     * {@code /model} switch: {@code taskStartedAt} captures when this turn
+     * was submitted, and we refuse to revert past an explicit later choice.
      */
-    private void syncEffectiveModelFromResult(JsonNode rpcMessage) {
+    private void syncEffectiveModelFromResult(JsonNode rpcMessage, Instant taskStartedAt) {
         if (rpcMessage == null) return;
+        Instant switchAt = lastLocalSwitchAt;
+        if (switchAt != null && taskStartedAt != null && taskStartedAt.isBefore(switchAt)) {
+            return;
+        }
         JsonNode result = rpcMessage.get("result");
         if (result == null) return;
         String actualModel = result.path("model").asText("");
@@ -1410,7 +1426,7 @@ public final class TerminalRepl {
         JsonNode message = handle.result();
         if (message == null) return;
 
-        syncEffectiveModelFromResult(message);
+        syncEffectiveModelFromResult(message, handle.startedAt());
         JsonNode result = message.get("result");
         if (result != null && result.has("usage")) {
             var usage = result.get("usage");
@@ -1882,7 +1898,7 @@ public final class TerminalRepl {
             // Guarded: a subsequent /fg on this already-completed handle would re-enter
             // renderTaskCompletion and try to account again; see markUsageAccounted contract.
             JsonNode bgResult = handle.result();
-            syncEffectiveModelFromResult(bgResult);
+            syncEffectiveModelFromResult(bgResult, handle.startedAt());
             if (bgResult != null && handle.markUsageAccounted()) {
                 JsonNode bgUsageResult = bgResult.get("result");
                 if (bgUsageResult != null && bgUsageResult.has("usage")) {
@@ -1959,7 +1975,7 @@ public final class TerminalRepl {
             if (handle.taskId().equals(taskManager.foregroundTaskId())) continue;
             if (!handle.markNotified()) continue;  // already shown — skip
 
-            syncEffectiveModelFromResult(handle.result());
+            syncEffectiveModelFromResult(handle.result(), handle.startedAt());
 
             String stateLabel = switch (handle.state()) {
                 case COMPLETED -> SUCCESS + "completed" + RESET;
@@ -4660,6 +4676,10 @@ public final class TerminalRepl {
                 out.println(ERROR + "Failed to switch model: " + error.path("message").asText() + RESET);
             } else {
                 effectiveModel = modelId;
+                // Record the switch time so stale background-task completions
+                // (which report the pre-switch model) can be filtered out by
+                // syncEffectiveModelFromResult.
+                lastLocalSwitchAt = Instant.now();
                 out.println(SUCCESS + "  \u2713 Switched to " + BOLD + modelId + RESET);
             }
             out.flush();

--- a/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/StreamingAgentHandler.java
+++ b/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/StreamingAgentHandler.java
@@ -603,7 +603,7 @@ public final class StreamingAgentHandler {
                     listener, planCheckpointStore, initialCheckpoint, session, 0);
         }
 
-        AdaptiveReplanner replanner = createReplannerIfEnabled(sessionId);
+        AdaptiveReplanner replanner = createReplannerIfEnabled(turnModel);
         var perStepWall = maxPlanStepWallTimeSec > 0
                 ? Duration.ofSeconds(maxPlanStepWallTimeSec) : null;
         var totalPlanWall = maxPlanTotalWallTimeSec > 0
@@ -656,7 +656,7 @@ public final class StreamingAgentHandler {
                 .merge(planResult.requestAttribution())
                 .merge(plannerAttribution.build())
                 .build();
-        recordRuntimeMetrics(sessionId, planResult.success(), planFirstTry,
+        recordRuntimeMetrics(sessionId, turnModel, planResult.success(), planFirstTry,
                 failedSteps, plannedStopReason, metricsCollector, session.projectPath(),
                 planUsage);
 
@@ -768,7 +768,7 @@ public final class StreamingAgentHandler {
         // Direct turn: firstTry = success without adaptive continuation segments
         boolean directFirstTry = turnSuccess && (adaptive == null || adaptive.continuationCount() == 0);
         int directRetryCount = adaptive != null ? adaptive.continuationCount() : 0;
-        recordRuntimeMetrics(sessionId, turnSuccess, directFirstTry,
+        recordRuntimeMetrics(sessionId, turnModel, turnSuccess, directFirstTry,
                 directRetryCount, turn.finalStopReason(), metricsCollector, session.projectPath(),
                 turn.requestAttribution());
 
@@ -1811,12 +1811,14 @@ public final class StreamingAgentHandler {
 
     /**
      * Creates an AdaptiveReplanner if adaptive replan is enabled, else returns null.
+     * Accepts the caller's captured turn model so a mid-turn {@code /model}
+     * switch can't leak into a late replan call.
      */
-    private AdaptiveReplanner createReplannerIfEnabled(String sessionId) {
+    private AdaptiveReplanner createReplannerIfEnabled(String turnModel) {
         if (!adaptiveReplanEnabled) {
             return null;
         }
-        return new AdaptiveReplanner(getLlmClient(), getModelForSession(sessionId));
+        return new AdaptiveReplanner(getLlmClient(), turnModel);
     }
 
     private dev.acecopilot.core.llm.LlmClient getLlmClient() {
@@ -2794,7 +2796,7 @@ public final class StreamingAgentHandler {
      * @param metricsCollector tool metrics for this session (may be null)
      * @param projectPath     project root for exporting runtime-latest.json
      */
-    private void recordRuntimeMetrics(String sessionId, boolean success, boolean firstTry,
+    private void recordRuntimeMetrics(String sessionId, String turnModel, boolean success, boolean firstTry,
                                        int retryCount, StopReason stopReason,
                                        ToolMetricsCollector metricsCollector, Path projectPath,
                                        RequestAttribution requestAttribution) {
@@ -2807,9 +2809,11 @@ public final class StreamingAgentHandler {
             // daemon-lifetime aggregate, so they flow into the counter here rather than at
             // export time. A /model switch mid-session produces new (provider, model)
             // buckets for subsequent turns while leaving earlier history correctly tagged.
+            // Use the caller's captured turn model (not a fresh lookup) so every request in
+            // a given turn attributes to the model that actually serviced it, even when a
+            // switch landed mid-turn.
             String provider = getLlmClient() != null ? getLlmClient().provider() : null;
-            String model = getModelForSession(sessionId);
-            exporter.recordLlmRequests(requestAttribution, provider, model);
+            exporter.recordLlmRequests(requestAttribution, provider, turnModel);
             if (stopReason == StopReason.MAX_TOKENS) {
                 exporter.recordTimeout();
             }
@@ -3324,7 +3328,7 @@ public final class StreamingAgentHandler {
                 cp.nextStepIndex());
 
         // 10. Execute remaining steps
-        AdaptiveReplanner resumeReplanner = createReplannerIfEnabled(sessionId);
+        AdaptiveReplanner resumeReplanner = createReplannerIfEnabled(turnModel);
         var perStepWall = maxPlanStepWallTimeSec > 0
                 ? Duration.ofSeconds(maxPlanStepWallTimeSec) : null;
         var totalPlanWall = maxPlanTotalWallTimeSec > 0
@@ -3372,7 +3376,7 @@ public final class StreamingAgentHandler {
         // so planResult.requestAttribution() is the full picture: step turns + any replans
         // during resumption. Same attribution goes to both runtime metrics and the payload.
         var resumedUsage = planResult.requestAttribution();
-        recordRuntimeMetrics(sessionId, planResult.success(), resumeFirstTry,
+        recordRuntimeMetrics(sessionId, turnModel, planResult.success(), resumeFirstTry,
                 resumeFailedSteps, plannedStopReason, metricsCollector, session.projectPath(),
                 resumedUsage);
 

--- a/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/StreamingAgentHandler.java
+++ b/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/StreamingAgentHandler.java
@@ -656,6 +656,7 @@ public final class StreamingAgentHandler {
         // 6. Build result
         var result = objectMapper.createObjectNode();
         result.put("sessionId", sessionId);
+        result.put("model", getModelForSession(sessionId));
         result.put("response", responseSummary);
         result.put("stopReason", "END_TURN");
         result.put("planned", true);
@@ -767,6 +768,7 @@ public final class StreamingAgentHandler {
         // Build result
         var result = objectMapper.createObjectNode();
         result.put("sessionId", sessionId);
+        result.put("model", getModelForSession(sessionId));
         result.put("response", responseText);
         result.put("stopReason", turn.finalStopReason().name());
         appendInjectedCandidateIds(result, sessionId);
@@ -2383,6 +2385,7 @@ public final class StreamingAgentHandler {
 
         var result = objectMapper.createObjectNode();
         result.put("sessionId", sessionId);
+        result.put("model", model);
         result.put("response", responseText != null ? responseText : "");
         result.put("stopReason", r.stopReason() != null ? r.stopReason() : "COMPLETE");
         if (cancellationToken.isCancelled()) result.put("cancelled", true);
@@ -3367,6 +3370,7 @@ public final class StreamingAgentHandler {
 
         var result = objectMapper.createObjectNode();
         result.put("sessionId", sessionId);
+        result.put("model", getModelForSession(sessionId));
         result.put("response", responseSummary);
         result.put("stopReason", "END_TURN");
         result.put("planned", true);

--- a/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/StreamingAgentHandler.java
+++ b/ace-copilot-daemon/src/main/java/dev/acecopilot/daemon/StreamingAgentHandler.java
@@ -299,6 +299,13 @@ public final class StreamingAgentHandler {
 
         log.info("Streaming agent prompt: sessionId={}, promptLength={}", sessionId, prompt.length());
 
+        // Capture the effective model once at turn entry. setModelOverride()
+        // writes the session map without taking turnLock, so a concurrent
+        // /model switch (especially against a backgrounded turn) would
+        // otherwise let the mid-turn planner, loop, and result reporter
+        // each see a different value.
+        final String turnModel = getModelForSession(sessionId);
+
         recordPromptSkillCorrections(sessionId, session.projectPath(), prompt);
 
         // Convert session conversation history to LLM messages
@@ -361,7 +368,7 @@ public final class StreamingAgentHandler {
                 .build();
         var permissionAwareLoop = new StreamingAgentLoop(
                 getLlmClient(), permissionAwareRegistry,
-                getModelForSession(sessionId), promptAssembly.prompt(),
+                turnModel, promptAssembly.prompt(),
                 maxTokens, thinkingBudget, contextWindowTokens, effectiveCompactor, agentConfig);
 
         // Acquire per-session turn lock (coordinates with DeferredActionScheduler)
@@ -379,14 +386,14 @@ public final class StreamingAgentHandler {
             // — those integrate in Phase 2+ (issues #4, #5).
             if ("session".equalsIgnoreCase(copilotRuntime) && "copilot".equalsIgnoreCase(provider)) {
                 return handlePromptViaCopilotSession(
-                        sessionId, session, prompt, cancelContext, cancellationToken,
+                        sessionId, turnModel, session, prompt, cancelContext, cancellationToken,
                         permissionAwareRegistry);
             }
 
             // Check for resumable plan checkpoint before planning or execution
             if (planCheckpointStore != null) {
                 var resumeResult = tryResumeFromCheckpoint(
-                        sessionId, session, cancelContext, eventHandler,
+                        sessionId, turnModel, session, cancelContext, eventHandler,
                         permissionAwareLoop, cancellationToken, metricsCollector, watchdog, requestToolNames);
                 if (resumeResult != null) {
                     sendBudgetExhaustedNotificationIfNeeded(watchdog, cancelContext, sessionId, cancellationToken);
@@ -402,7 +409,7 @@ public final class StreamingAgentHandler {
                 if (complexityScore.shouldPlan()) {
                     log.info("Complex task detected (score={}, signals={}), generating plan",
                             complexityScore.score(), complexityScore.signals());
-                    var planResult = executePlannedPrompt(prompt, session, sessionId, cancelContext,
+                    var planResult = executePlannedPrompt(prompt, session, sessionId, turnModel, cancelContext,
                             eventHandler, permissionAwareLoop, cancellationToken,
                             metricsCollector, watchdog, requestToolNames);
                     sendBudgetExhaustedNotificationIfNeeded(watchdog, cancelContext, sessionId, cancellationToken);
@@ -417,7 +424,7 @@ public final class StreamingAgentHandler {
             sendCancelledNotificationIfNeeded(cancellationToken, cancelContext, sessionId);
             sendBudgetExhaustedNotificationIfNeeded(watchdog, cancelContext, sessionId, cancellationToken);
 
-            return buildTurnResult(adaptive.turn(), session, sessionId, prompt, cancellationToken, metricsCollector,
+            return buildTurnResult(adaptive.turn(), session, sessionId, turnModel, prompt, cancellationToken, metricsCollector,
                     adaptive, requestToolNames);
 
         } catch (dev.acecopilot.core.llm.LlmException e) {
@@ -448,14 +455,14 @@ public final class StreamingAgentHandler {
      * then executes each step sequentially through the agent loop.
      */
     private Object executePlannedPrompt(
-            String prompt, AgentSession session, String sessionId,
+            String prompt, AgentSession session, String sessionId, String turnModel,
             StreamContext cancelContext, StreamEventHandler eventHandler,
             StreamingAgentLoop permissionAwareLoop, CancellationToken cancellationToken,
             ToolMetricsCollector metricsCollector, WatchdogTimer watchdog,
             Set<String> requestToolNames) throws Exception {
 
         // 1. Generate plan
-        var planner = new LLMTaskPlanner(getLlmClient(), getModelForSession(sessionId));
+        var planner = new LLMTaskPlanner(getLlmClient(), turnModel);
         var toolDefs = toolRegistry.toDefinitions();
 
         // Capture the planner's own LLM request separately from step/replan attribution so
@@ -473,7 +480,7 @@ public final class StreamingAgentHandler {
             var adaptive = runTurnWithAdaptiveContinuation(
                     permissionAwareLoop, prompt, conversationHistory, eventHandler, cancellationToken);
             sendCancelledNotificationIfNeeded(cancellationToken, cancelContext, sessionId);
-            return buildTurnResult(adaptive.turn(), session, sessionId, prompt, cancellationToken, metricsCollector,
+            return buildTurnResult(adaptive.turn(), session, sessionId, turnModel, prompt, cancellationToken, metricsCollector,
                     adaptive, requestToolNames);
         }
 
@@ -656,7 +663,7 @@ public final class StreamingAgentHandler {
         // 6. Build result
         var result = objectMapper.createObjectNode();
         result.put("sessionId", sessionId);
-        result.put("model", getModelForSession(sessionId));
+        result.put("model", turnModel);
         result.put("response", responseSummary);
         result.put("stopReason", "END_TURN");
         result.put("planned", true);
@@ -722,7 +729,7 @@ public final class StreamingAgentHandler {
      * Builds the standard turn result object (shared between direct and fallback-from-plan paths).
      */
     private Object buildTurnResult(dev.acecopilot.core.agent.Turn turn, AgentSession session,
-                                    String sessionId, String prompt,
+                                    String sessionId, String turnModel, String prompt,
                                     CancellationToken cancellationToken,
                                     ToolMetricsCollector metricsCollector,
                                     AdaptiveTurnResult adaptive,
@@ -768,7 +775,7 @@ public final class StreamingAgentHandler {
         // Build result
         var result = objectMapper.createObjectNode();
         result.put("sessionId", sessionId);
-        result.put("model", getModelForSession(sessionId));
+        result.put("model", turnModel);
         result.put("response", responseText);
         result.put("stopReason", turn.finalStopReason().name());
         appendInjectedCandidateIds(result, sessionId);
@@ -2212,6 +2219,7 @@ public final class StreamingAgentHandler {
      * </ul>
      */
     private Object handlePromptViaCopilotSession(String sessionId,
+                                                 String turnModel,
                                                  AgentSession session,
                                                  String prompt,
                                                  CancelAwareStreamContext cancelContext,
@@ -2226,7 +2234,7 @@ public final class StreamingAgentHandler {
 
         session.addMessage(new AgentSession.ConversationMessage.User(prompt));
 
-        String model = getModelForSession(sessionId);
+        String model = turnModel;
         // Session-mode billing = published multiplier × 3 (verified). Haiku
         // stays cheapest: 0.33 × 3 = 1 premium/turn vs Sonnet 1 × 3 = 3.
         // Default to Haiku so operators are billed 1x by default; Sonnet/
@@ -3054,7 +3062,7 @@ public final class StreamingAgentHandler {
      * was accepted and executed, or null if no checkpoint found or user declined.
      */
     private Object tryResumeFromCheckpoint(
-            String sessionId, AgentSession session,
+            String sessionId, String turnModel, AgentSession session,
             StreamContext cancelContext, StreamEventHandler eventHandler,
             StreamingAgentLoop permissionAwareLoop, CancellationToken cancellationToken,
             ToolMetricsCollector metricsCollector, WatchdogTimer watchdog,
@@ -3088,7 +3096,7 @@ public final class StreamingAgentHandler {
         boolean userAccepted = offerResumeAndWaitForResponse(cancelContext, cp);
 
         if (userAccepted && cp.hasRemainingSteps()) {
-            return executeResumedPlan(cp, session, sessionId, cancelContext,
+            return executeResumedPlan(cp, session, sessionId, turnModel, cancelContext,
                     eventHandler, permissionAwareLoop, cancellationToken, metricsCollector, watchdog,
                     requestToolNames);
         }
@@ -3148,7 +3156,7 @@ public final class StreamingAgentHandler {
      * Executes a plan from a checkpoint, resuming from the last completed step.
      */
     private Object executeResumedPlan(
-            PlanCheckpoint cp, AgentSession session, String sessionId,
+            PlanCheckpoint cp, AgentSession session, String sessionId, String turnModel,
             StreamContext cancelContext, StreamEventHandler eventHandler,
             StreamingAgentLoop permissionAwareLoop, CancellationToken cancellationToken,
             ToolMetricsCollector metricsCollector, WatchdogTimer watchdog,
@@ -3370,7 +3378,7 @@ public final class StreamingAgentHandler {
 
         var result = objectMapper.createObjectNode();
         result.put("sessionId", sessionId);
-        result.put("model", getModelForSession(sessionId));
+        result.put("model", turnModel);
         result.put("response", responseSummary);
         result.put("stopReason", "END_TURN");
         result.put("planned", true);


### PR DESCRIPTION
## Summary
- Observed: TUI bottom bar showed `◆ claude-haiku-4.5` while every turn actually dispatched `claude-sonnet-4.6` (confirmed via daemon log `Copilot session turn: ..., model=claude-sonnet-4.6, ...`). User's billing went up 3× expected and blame pointed at Haiku before we realized the display was lying.
- Root cause: `TerminalRepl.effectiveModel` is cached once at TUI startup from `health.status` and only updated on successful local `/model X`. It drifts whenever daemon state changes without the TUI originating it — daemon restarts with a different profile, per-session overrides, etc.
- Fix: daemon now includes `"model"` in every `agent.prompt` result (4 builders — fresh plan, direct turn, Copilot session, checkpoint resume). TUI reads it at turn completion and overwrites `effectiveModel` if it drifts; the bottom status bar's next repaint reflects reality.

## Compatibility
- Old CLIs silently ignore the new field.
- Old daemons omit it; TUI's empty-string guard keeps the cached value.

## Test plan
- [x] `./gradlew :ace-copilot-daemon:test :ace-copilot-cli:test --rerun-tasks` passes
- [ ] Manual: start daemon with `copilot-sonnet` profile, TUI from an older haiku-era process, send a turn → status bar updates to `claude-sonnet-4.6` after completion
- [ ] Manual: `/model claude-haiku-4.5` still updates immediately (unchanged path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)